### PR TITLE
Update typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Idiomorph supports the following options:
 | `morphstyle`   | The style of morphing to use, either `innerHTML` or `outerHTML`                                             | `Idiomorph.morph(..., {morphStyle:'innerHTML'})`                        |
 | `ignoreActive` | If set to `true`, idiomorph will skip the active element                                                    | `Idiomorph.morph(..., {ignoreActive:true})`                             |
 | `head`         | Allows you to control how the `head` tag is merged.  See the [head](#the-head-tag) section for more details | `Idiomorph.morph(..., {head:{style:merge}})`                            |
-| `callbacks`    | Allows you to insert callbacks when events occur in the morph life cycle, see the callback table below      | `Idiomorph.morph(..., {callback:{beforeNodeAdded:function(node){...}})` |
+| `callbacks`    | Allows you to insert callbacks when events occur in the morph life cycle, see the callback table below      | `Idiomorph.morph(..., {callbacks:{beforeNodeAdded:function(node){...}})` |
 
 #### Callbacks
 


### PR DESCRIPTION
added missing `s` in callbacks configuration example