### PR TITLE
Fix input property sync

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -283,8 +283,9 @@
                 }
             }
 
-            function syncAttribute(from, to, attributeName) {
+            function syncBooleanAttribute(from, to, attributeName) {
                 if (from[attributeName] !== to[attributeName]) {
+                    to[attributeName] = from[attributeName];
                     if (from[attributeName]) {
                         to.setAttribute(attributeName, from[attributeName]);
                     } else {
@@ -302,14 +303,22 @@
                     to instanceof HTMLInputElement &&
                     from.type !== 'file') {
 
-                    to.value = from.value || '';
-                    syncAttribute(from, to, 'value');
+                    let fromValue = from.value;
+                    let toValue = to.value;
 
                     // sync boolean attributes
-                    syncAttribute(from, to, 'checked');
-                    syncAttribute(from, to, 'disabled');
+                    syncBooleanAttribute(from, to, 'checked');
+                    syncBooleanAttribute(from, to, 'disabled');
+
+                    if (!from.hasAttribute('value')) {
+                        to.value = '';
+                        to.removeAttribute('value');
+                    } else if (fromValue !== toValue) {
+                        to.setAttribute('value', fromValue);
+                        to.value = fromValue;
+                    }
                 } else if (from instanceof HTMLOptionElement) {
-                    syncAttribute(from, to, 'selected')
+                    syncBooleanAttribute(from, to, 'selected')
                 } else if (from instanceof HTMLTextAreaElement && to instanceof HTMLTextAreaElement) {
                     let fromValue = from.value;
                     let toValue = to.value;

--- a/test/core.js
+++ b/test/core.js
@@ -266,5 +266,74 @@ describe("Core morphing tests", function(){
         document.body.removeChild(parent);
     });
 
+    it('can morph input checked properly, remove checked', function()
+    {
+        let parent = make('<div><input type="checkbox" checked></div>');
+        document.body.append(parent);
+        let initial = parent.querySelector("input");
 
+        let finalSrc = '<input type="checkbox">';
+        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
+        if (initial.outerHTML !== '<input type="checkbox">') {
+            console.log("HTML after morph: " + initial.outerHTML);
+            console.log("Expected:         " + finalSrc);
+        }
+        initial.outerHTML.should.equal('<input type="checkbox">');
+        initial.checked.should.equal(false);
+        document.body.removeChild(parent);
+    });
+
+    it('can morph input checked properly, add checked', function()
+    {
+        let parent = make('<div><input type="checkbox"></div>');
+        document.body.append(parent);
+        let initial = parent.querySelector("input");
+
+        let finalSrc = '<input type="checkbox" checked>';
+        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
+        if (initial.outerHTML !== '<input type="checkbox" checked="">') {
+            console.log("HTML after morph: " + initial.outerHTML);
+            console.log("Expected:         " + finalSrc);
+        }
+        initial.outerHTML.should.equal('<input type="checkbox" checked="">');
+        initial.checked.should.equal(true);
+        document.body.removeChild(parent);
+    });
+
+    it('can morph input checked properly, set checked property to true', function()
+    {
+        let parent = make('<div><input type="checkbox" checked></div>');
+        document.body.append(parent);
+        let initial = parent.querySelector("input");
+        initial.checked = false;
+
+        let finalSrc = '<input type="checkbox" checked>';
+        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
+        if (initial.outerHTML !== '<input type="checkbox" checked="true">') {
+            console.log("HTML after morph: " + initial.outerHTML);
+            console.log("Expected:         " + finalSrc);
+        }
+        initial.outerHTML.should.equal('<input type="checkbox" checked="true">');
+        initial.checked.should.equal(true);
+        document.body.removeChild(parent);
+    });
+
+    it('can morph input checked properly, set checked property to false', function()
+    {
+        let parent = make('<div><input type="checkbox"></div>');
+        document.body.append(parent);
+        let initial = parent.querySelector("input");
+        initial.checked = true;
+
+        let finalSrc = '<input type="checkbox">';
+        initial.checked = false;
+        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
+        if (initial.outerHTML !== '<input type="checkbox">') {
+            console.log("HTML after morph: " + initial.outerHTML);
+            console.log("Expected:         " + finalSrc);
+        }
+        initial.outerHTML.should.equal('<input type="checkbox">');
+        initial.checked.should.equal(false);
+        document.body.removeChild(parent);
+    });
 })


### PR DESCRIPTION
idiomorph has a bug introduced in the latest release 0.0.9, where it syncs the `checked` attribute of `<input>` but does not sync the `checked` property. it is actually one line, but there were also changes for the order for the sync of checked (and others) and value, I'll apply chesterton's fence here.

just to be sure I migrated some unit tests from nanomorph's tape test suite [1] to idiomorphs mocha test suite.

[1] https://github.com/choojs/nanomorph/blob/v5.4.3/test/diff.js#L125-L245