### PR TITLE
Fix input property sync test

### DIFF
--- a/test/core.js
+++ b/test/core.js
@@ -326,7 +326,6 @@ describe("Core morphing tests", function(){
         initial.checked = true;
 
         let finalSrc = '<input type="checkbox">';
-        initial.checked = false;
         Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
         if (initial.outerHTML !== '<input type="checkbox">') {
             console.log("HTML after morph: " + initial.outerHTML);


### PR DESCRIPTION
One stray line that makes the test case a no-test.

Not critical since there are no changes needed to `idiomorph.js`, i.e. I'm fixing the test to let it catch regressions in the future.

**testing strategy:**

- `❯ pnpm install`
- uncomment test suites that also fail on `main` branch on my machine in `test/index.html`:
```html
<!-- <script src="perf.js"></script> -->
<!-- <script src="head.js"></script> -->
```
- `❯ pnpm run test`