### PR TITLE
Fix isInlineSwap on defineExtension

### DIFF
--- a/src/idiomorph-htmx.js
+++ b/src/idiomorph-htmx.js
@@ -12,7 +12,7 @@
     htmx.defineExtension('morph', {
         isInlineSwap: function(swapStyle) {
             let config = createMorphConfig(swapStyle);
-            return config.swapStyle === "outerHTML" || config.swapStyle == null;
+            return config?.morphStyle === "outerHTML" || config?.morphStyle == null;
         },
         handleSwap: function (swapStyle, target, fragment) {
             let config = createMorphConfig(swapStyle);


### PR DESCRIPTION
Anytime a non "morph" swap style is uses while the extension is enabled causes the `inlineSwap` handler to crash.

Since the morph config has a `morphStyle` property, but not a `swapStyle` property, I assume this is just a typo.