### PR TITLE
Exclude `document.body` when morphing with `ignoreActiveValue: true`

### DIFF
--- a/dist/idiomorph.amd.js
+++ b/dist/idiomorph.amd.js
@@ -112,7 +112,7 @@ var Idiomorph = (function () {
          * @returns {boolean}
          */
         function ignoreValueOfActiveElement(possibleActiveElement, ctx) {
-            return ctx.ignoreActiveValue && possibleActiveElement === document.activeElement;
+            return ctx.ignoreActiveValue && possibleActiveElement === document.activeElement && possibleActiveElement !== document.body;
         }
 
         /**

--- a/dist/idiomorph.cjs.js
+++ b/dist/idiomorph.cjs.js
@@ -110,7 +110,7 @@ var Idiomorph = (function () {
          * @returns {boolean}
          */
         function ignoreValueOfActiveElement(possibleActiveElement, ctx) {
-            return ctx.ignoreActiveValue && possibleActiveElement === document.activeElement;
+            return ctx.ignoreActiveValue && possibleActiveElement === document.activeElement && possibleActiveElement !== document.body;
         }
 
         /**

--- a/dist/idiomorph.esm.js
+++ b/dist/idiomorph.esm.js
@@ -110,7 +110,7 @@ var Idiomorph = (function () {
          * @returns {boolean}
          */
         function ignoreValueOfActiveElement(possibleActiveElement, ctx) {
-            return ctx.ignoreActiveValue && possibleActiveElement === document.activeElement;
+            return ctx.ignoreActiveValue && possibleActiveElement === document.activeElement && possibleActiveElement !== document.body;
         }
 
         /**

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -110,7 +110,7 @@ var Idiomorph = (function () {
          * @returns {boolean}
          */
         function ignoreValueOfActiveElement(possibleActiveElement, ctx) {
-            return ctx.ignoreActiveValue && possibleActiveElement === document.activeElement;
+            return ctx.ignoreActiveValue && possibleActiveElement === document.activeElement && possibleActiveElement !== document.body;
         }
 
         /**

--- a/test/core.js
+++ b/test/core.js
@@ -241,6 +241,28 @@ describe("Core morphing tests", function(){
         document.body.removeChild(parent);
     });
 
+    it('does not ignore body when ignoreActiveValue is true and no element has focus', function()
+    {
+        let parent = make("<div><input value='foo'></div>");
+        document.body.append(parent);
+
+        let initial = parent.querySelector("input");
+
+        // morph
+        let finalSrc = '<input value="bar">';
+        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
+        initial.outerHTML.should.equal('<input value="bar">');
+
+        document.activeElement.should.equal(initial);
+
+        let finalSrc2 = '<input class="foo" value="doh">';
+        Idiomorph.morph(initial, finalSrc2, {morphStyle:'outerHTML', ignoreActiveValue: true});
+        initial.value.should.equal('doh');
+        initial.classList.value.should.equal('foo');
+
+        document.body.removeChild(parent);
+    });
+
     it('can ignore attributes w/ the beforeAttributeUpdated callback', function()
     {
         let parent = make("<div><input value='foo'></div>");


### PR DESCRIPTION
When morphing with `ignoreActiveValue: true`, the `<body>` element and its children (that is, the entire document) can be preserved if no other element has focus.

Its common in some browsers (for example, Safari) to return `document.body` from `document.activeElement` when no other element has focus.

This commit incorporates that condition into the
`ignoreValueOfActiveElement()` predicate function.