### PR TITLE
Advertising the ESM file with the "module" key

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dist/*.js"
   ],
   "main": "dist/idiomorph.js",
+  "module": "dist/idiomorph.esm.js",
   "unpkg": "dist/idiomorph.min.js",
   "scripts": {
     "test": "mocha-chrome test/index.html",


### PR DESCRIPTION
Hi!

Fixes #28. Using:


```js
import { Idiomorph } from "idiomorph/dist/idiomorph.esm";
```

already works, as indicated by the README.md file. However, by adding the `module` key, users in a module environment will simply be able to say:

```js
import { Idiomorph } from "idiomorph";
```

Additionally, some CDN's like jsdelivr package an ESM version. As you can see, the current version is an empty file - https://cdn.jsdelivr.net/npm/idiomorph@0.3.0/+esm - the reason being that they look for the `module` key to know which file to use (see `Locating entry points` on https://github.com/jsdelivr/jsdelivr/issues/18263 ).

I am not an absolute expert on this topic, but I'm fairly confident with this PR. 

Thanks!