### PR TITLE
Fix license short identifier in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": {
     "url": "https://github.com/bigskysoftware/idiomorph/issues"
   },
-  "license": "BSD 2-Clause",
+  "license": "BSD-2-Clause",
   "files": [
     "LICENSE",
     "README.md",


### PR DESCRIPTION
The SPDX short identifier for BSD 2-Clause is `BSD-2-Clause`

- https://spdx.org/licenses/BSD-2-Clause.html