### PR TITLE
Fix failing test

### DIFF
--- a/test/core.js
+++ b/test/core.js
@@ -253,7 +253,7 @@ describe("Core morphing tests", function(){
         Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
         initial.outerHTML.should.equal('<input value="bar">');
 
-        document.activeElement.should.equal(initial);
+        document.activeElement.should.equal(document.body);
 
         let finalSrc2 = '<input class="foo" value="doh">';
         Idiomorph.morph(initial, finalSrc2, {morphStyle:'outerHTML', ignoreActiveValue: true});


### PR DESCRIPTION
Follow-up to [#34][]

As mentioned in a [comment on #34][], the test suite wasn't executed when the code was initially contributed. When opening `test/index.html` locally in a browser, there is a single test failure:

```
does not ignore body when ignoreActiveValue is true and no element has focus ‣
  AssertionError: expected <body …(1)>…(28)</body> to equal <input value="bar"></input>@[native code]
```

This commit resolves that failure by changing the test to more accurately exercise the desired behavior.

[#34]: https://github.com/bigskysoftware/idiomorph/pull/34
[comment on #34]: https://github.com/bigskysoftware/idiomorph/pull/34#discussion_r1466591489