### PR TITLE
Improve morph support for `<template>` elements

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -307,6 +307,10 @@ var Idiomorph = (function () {
          * @returns {void}
          */
         function morphChildren(newParent, oldParent, ctx) {
+            if (newParent instanceof HTMLTemplateElement && oldParent instanceof HTMLTemplateElement) {
+              newParent = newParent.content;
+              oldParent = oldParent.content;
+            }
 
             /**
              *

--- a/test/core.js
+++ b/test/core.js
@@ -185,6 +185,14 @@ describe("Core morphing tests", function(){
         initial.outerHTML.should.equal("<div></div>");
     });
 
+    it('can morph a template tag properly', function()
+    {
+      let initial = make("<template data-old>Foo</template>");
+      let final = make("<template data-new>Bar</template>");
+      Idiomorph.morph(initial, final);
+      initial.outerHTML.should.equal(final.outerHTML);
+    });
+
     it('ignores active element when ignoreActive set to true', function()
     {
         let initialSource = "<div><div id='d1'>Foo</div><input id='i1'></div>";


### PR DESCRIPTION
Closes [#15][]

When morphing `<template>` elements, treat the [DocumentFragment][]
instances returned from the [HTMLTemplateElement.content][] properties
as `morphChildren` methods' `newParent` and `oldParent` variables.

That way, descendant nodes can be iterated across the
connected-disconnected boundary.

[#15]: https://github.com/bigskysoftware/idiomorph/issues/15
[DocumentFragment]: https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment
[HTMLTemplateElement.content]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement/content

