### PR TITLE
Move matching nodes, rather than deleting up to them

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -137,6 +137,8 @@ var Idiomorph = (function () {
                 ctx.callbacks.afterNodeRemoved(oldNode);
                 return newContent;
             } else {
+                if (insertBefore) insertBefore.before(oldNode)
+
                 if (ctx.callbacks.beforeNodeMorphed(oldNode, newContent) === false) return oldNode;
 
                 if (oldNode instanceof HTMLHeadElement && ctx.head.ignore) {
@@ -144,7 +146,6 @@ var Idiomorph = (function () {
                 } else if (oldNode instanceof HTMLHeadElement && ctx.head.style !== "morph") {
                     handleHeadElement(newContent, oldNode, ctx);
                 } else {
-                    if (insertBefore) insertBefore.before(oldNode)
                     syncNodeFrom(newContent, oldNode, ctx);
                     if (!ignoreValueOfActiveElement(oldNode, ctx)) {
                         morphChildren(newContent, oldNode, ctx);

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -119,7 +119,7 @@ var Idiomorph = (function () {
          * @param ctx the merge context
          * @returns {Element} the element that ended up in the DOM
          */
-        function morphOldNodeTo(oldNode, newContent, ctx) {
+        function morphOldNodeTo(oldNode, newContent, ctx, { insertBefore } = {}) {
             if (ctx.ignoreActive && oldNode === document.activeElement) {
                 // don't morph focused element
             } else if (newContent == null) {
@@ -144,6 +144,7 @@ var Idiomorph = (function () {
                 } else if (oldNode instanceof HTMLHeadElement && ctx.head.style !== "morph") {
                     handleHeadElement(newContent, oldNode, ctx);
                 } else {
+                    if (insertBefore) insertBefore.before(oldNode)
                     syncNodeFrom(newContent, oldNode, ctx);
                     if (!ignoreValueOfActiveElement(oldNode, ctx)) {
                         morphChildren(newContent, oldNode, ctx);
@@ -209,10 +210,9 @@ var Idiomorph = (function () {
                 // otherwise search forward in the existing old children for an id set match
                 let idSetMatch = findIdSetMatch(newParent, oldParent, newChild, insertionPoint, ctx);
 
-                // if we found a match, move it to just before the insertion point and morph it
+                // if we found a match, morph it and move it to just before the insertion point
                 if (idSetMatch) {
-                    insertionPoint.before(idSetMatch);
-                    morphOldNodeTo(idSetMatch, newChild, ctx);
+                    morphOldNodeTo(idSetMatch, newChild, ctx, { insertBefore: insertionPoint });
                     removeIdsFromConsideration(ctx, newChild);
                     continue;
                 }

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -585,6 +585,10 @@ var Idiomorph = (function () {
 
                     // If we have an id match, return the current potential match
                     if (isIdSetMatch(newChild, potentialMatch, ctx)) {
+                        // If the potential match isn't a perfect fit, but one of its descendants is, return that instead
+                        if (newChild.id !== potentialMatch.id && ctx.idMap.get(potentialMatch).has(newChild.id)) {
+                            return potentialMatch.querySelector("#"+newChild.id);
+                        }
                         return potentialMatch;
                     }
 

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -190,7 +190,7 @@ var Idiomorph = (function () {
 
                 // if we are at the end of the exiting parent's children, just append
                 if (insertionPoint == null) {
-                    if (ctx.callbacks.beforeNodeAdded(newChild) === false) return;
+                    if (ctx.callbacks.beforeNodeAdded(newChild) === false) continue;
 
                     oldParent.appendChild(newChild);
                     ctx.callbacks.afterNodeAdded(newChild);
@@ -230,7 +230,7 @@ var Idiomorph = (function () {
 
                 // abandon all hope of morphing, just insert the new child before the insertion point
                 // and move on
-                if (ctx.callbacks.beforeNodeAdded(newChild) === false) return;
+                if (ctx.callbacks.beforeNodeAdded(newChild) === false) continue;
 
                 oldParent.insertBefore(newChild, insertionPoint);
                 ctx.callbacks.afterNodeAdded(newChild);

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -222,8 +222,14 @@ var Idiomorph = (function () {
 
                 // if we found a soft match for the current node, morph
                 if (softMatch) {
-                    insertionPoint = removeNodesBetween(insertionPoint, softMatch, ctx);
-                    morphOldNodeTo(softMatch, newChild, ctx);
+                    // if the current node is a soft match then morph
+                    if (insertionPoint === softMatch) {
+                      morphOldNodeTo(softMatch, newChild, ctx);
+                      insertionPoint = insertionPoint.nextSibling;
+                    // otherwise, morph it and move it to just before the insertion point
+                    } else {
+                      morphOldNodeTo(softMatch, newChild, ctx, { insertBefore: insertionPoint });
+                    }
                     removeIdsFromConsideration(ctx, newChild);
                     continue;
                 }

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -209,9 +209,9 @@ var Idiomorph = (function () {
                 // otherwise search forward in the existing old children for an id set match
                 let idSetMatch = findIdSetMatch(newParent, oldParent, newChild, insertionPoint, ctx);
 
-                // if we found a potential match, remove the nodes until that point and morph
+                // if we found a match, move it to just before the insertion point and morph it
                 if (idSetMatch) {
-                    insertionPoint = removeNodesBetween(insertionPoint, idSetMatch, ctx);
+                    insertionPoint.before(idSetMatch);
                     morphOldNodeTo(idSetMatch, newChild, ctx);
                     removeIdsFromConsideration(ctx, newChild);
                     continue;
@@ -575,24 +575,11 @@ var Idiomorph = (function () {
             // only search forward if there is a possibility of an id match
             if (newChildPotentialIdCount > 0) {
                 let potentialMatch = insertionPoint;
-                // if there is a possibility of an id match, scan forward
-                // keep track of the potential id match count we are discarding (the
-                // newChildPotentialIdCount must be greater than this to make it likely
-                // worth it)
-                let otherMatchCount = 0;
                 while (potentialMatch != null) {
 
                     // If we have an id match, return the current potential match
                     if (isIdSetMatch(newChild, potentialMatch, ctx)) {
                         return potentialMatch;
-                    }
-
-                    // computer the other potential matches of this new content
-                    otherMatchCount += getIdIntersectionCount(ctx, potentialMatch, newContent);
-                    if (otherMatchCount > newChildPotentialIdCount) {
-                        // if we have more potential id matches in _other_ content, we
-                        // do not have a good candidate for an id match, so return null
-                        return null;
                     }
 
                     // advanced to the next old content child

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -55,8 +55,8 @@ describe("Bootstrap test", function(){
         Idiomorph.morph(div1, div2);
         print(div1);
 
-        // first paragraph should have been discarded in favor of later matches
-        d1.innerHTML.should.equal("A");
+        // first paragraph should have been moved and morphed
+        d1.innerHTML.should.equal("D");
 
         // second and third paragraph should have morphed
         d2.innerHTML.should.equal("E");

--- a/test/demo/swap_videos.html
+++ b/test/demo/swap_videos.html
@@ -1,0 +1,63 @@
+<html>
+<head>
+    <script src="../../src/idiomorph.js"></script>
+    <style>
+        div, button {
+            margin:16px;
+        }
+    </style>
+</head>
+<body>
+
+<div id="idiomorph">
+    <div id="flower-header">
+        <h3>Flower</h3>
+    </div>
+    <div id="flower-video">
+        <video width="640" height="360" controls>
+            <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4" type="video/mp4">
+        </video>
+    </div>
+    <div id="bunny-header">
+        <h3>Bunny</h3>
+    </div>
+    <div id="bunny-video">
+        <video width="640" height="360" controls>
+            <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4">
+        </video>
+    </div>
+</div>
+
+<button onclick="playVideosAndMorph()">
+    Play and Swap Videos
+</button>
+<script>
+    function playVideosAndMorph() {
+        document.querySelectorAll('video').forEach(e => e.play())
+        Idiomorph.morph(
+            document.getElementById('idiomorph'),
+            document.getElementById('idiomorph-after').content.cloneNode(true),
+            { morphStyle: 'innerHTML' },
+        )
+    }
+</script>
+
+<template id="idiomorph-after">
+    <div id="bunny-header">
+        <h3>Bunny</h3>
+    </div>
+    <div id="bunny-video">
+        <video width="640" height="360" controls>
+            <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4">
+        </video>
+    </div>
+    <div id="flower-header">
+        <h3>Flower</h3>
+    </div>
+    <div id="flower-video">
+        <video width="640" height="360" controls>
+            <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4" type="video/mp4">
+        </video>
+    </div>
+</template>
+


### PR DESCRIPTION
Hello, thank you so much for Idiomorph! It's a key component in making it possible to make modern-feeling apps with just server-side rendering. What an amazing gift to the world! I hope you will consider merging this PR to improve it further.

## Context
I'm currently using [Turbo](https://github.com/hotwired/turbo) + Idiomorph to build a collaborative project management app in the style of Pivotal Tracker (RIP). A core interaction of this app is reordering items by dragging and dropping. This change gets sent over the wire to other active users, and Idiomorph updates their screen with the new order.

## Issue
However, I submit that Idiomorph's core algorithm doesn't handle reordering operations very well at the moment. Imagine the following scenario:
1. Alice and Bob are collaborating on a project with five items: 1, 2, 3, 4, 5
2. Bob is currently in item 3, writing a new comment in a `textarea[data-turbo-permanent]` (akin to `hx-preserve`)
3. Alice drags item 5 to the top of the list, to mark it as top priority: 5, 1, 2, 3, 4
4. The new list HTML gets sent over the wire to Bob, and Idiomorph begins to morph the old list into the new
5. Starting with the top item, item 5, it finds a match at the bottom of the old HTML
6. _**It deletes items 1, 2, 3, and 4 so that item 5 is now in the correct position on top**_
7. _**It finds no matches for items 1, 2, 3, and 4, so it adds them from scratch, one by one**_
8. Bob's screen now looks like Alice's, except it completely blew away the contents of his comment text box, and now he has to start over. Bob is angry.

## Proposed solution in this PR
1-5. Same as above
6. It moves item 5 to the current insertion point with `Element.before`.
7. Items 1, 2, 3, and 4 match perfectly so they are kept in the DOM as-is.
8. Bob's screen now looks like Alice's, and he continues writing his comment without interruption. Bob is wistfully thinking about what he ate for breakfast.

Personally, I can see no downside to this strategy, other than perhaps more time spent in `findIdSetMatch` since its no longer bailing early to preserve potential future matches. But I expect that would be more than made up for less time spent in unnecessary DOM removal and reinsertion operations. Of course, I haven't done the deep dive into this domain that you have, so I'm sure you have more much insight into this.

So what do you think? Any reason not to do this?

## Demo
I've added a video demo in the first commit that demonstrates the issue, and then also demonstrates the fix after the second commit is applied.

### Before
![before](https://github.com/user-attachments/assets/62761cc5-9b84-433d-940e-4d4b7f9082a8)

### After
![after](https://github.com/user-attachments/assets/446ceecc-a36c-4bc1-8b0c-ec38eb9cb623)