### PR TITLE
Set up GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '16'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm test
+


### PR DESCRIPTION
Hi @1cg, I've got something working here. Some notes:

1. CI won't run in PRs (including this one) until the `main` branch has the CI action.
2. So to prove that this PR does what it says it does, here's the same commit SHA running on my fork: https://github.com/botandrose/idiomorph/actions/runs/11441381562/job/31829306598
3. This test run failed, but it looks to be an accurate state of the repo, because I'm seeing this exact same result when I run it locally.
4. Once this is merged I'll write a follow-up PR getting CI green again.
5. I had to pin Node to 16 because `mocha-chrome` doesnt work with 17+: https://github.com/shellscape/mocha-chrome/issues/46#issuecomment-2327484283 . `mocha-chrome` seems to be unmaintained, so I imagine we'll want to switch it out for something else, later.