### PR TITLE
bugfix: fix htmx integration when innerHTML swap strategy is used

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -201,7 +201,7 @@ var Idiomorph = (function () {
 
                 // innerHTML, so we are only updating the children
                 morphChildren(normalizedNewContent, oldNode, ctx);
-                return oldNode.children;
+                return Array.from(oldNode.children);
 
             } else if (ctx.morphStyle === "outerHTML" || ctx.morphStyle == null) {
                 // otherwise find the best element match in the new content, morph that, and merge its siblings


### PR DESCRIPTION
The htmx integration was broken when `morph:innerHTML` swap strategy was used. Namely the morphed content did not get processed by htmx.

The reason for this was, that the return type of the `morph` function was inconsistent. When `outerHTML` swap strategy gets used, idiomorph returns an array, but with `innerHTML` a HTMLCollection was returned, see https://github.com/bigskysoftware/idiomorph/blob/main/src/idiomorph.js#L204

htmx checks if the returned value of a swap by an extension is an array. This check fails for HTMLCollections and thus the content doesn't get processed. See https://github.com/bigskysoftware/htmx/blob/master/src/htmx.js#L1788

I decided to fix the issue by converting the HTMLCollection to an array directly in the `morphNormalizedContent` function to make the return type consistent (see https://github.com/marcobeierer/idiomorph/blob/main/src/idiomorph.js#L204).

However, this could be a breaking change if someone just uses innerHTML strategy and relies on the return type. An alternative would be to just fix the htmx integration and convert the return value of `handleSwap` at https://github.com/bigskysoftware/idiomorph/blob/main/src/idiomorph-htmx.js#L20