### PR TITLE
Fix early return

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -332,7 +332,7 @@ var Idiomorph = (function () {
 
                 // if we are at the end of the exiting parent's children, just append
                 if (insertionPoint == null) {
-                    if (ctx.callbacks.beforeNodeAdded(newChild) === false) return;
+                    if (ctx.callbacks.beforeNodeAdded(newChild) === false) continue;
 
                     oldParent.appendChild(newChild);
                     ctx.callbacks.afterNodeAdded(newChild);
@@ -372,7 +372,7 @@ var Idiomorph = (function () {
 
                 // abandon all hope of morphing, just insert the new child before the insertion point
                 // and move on
-                if (ctx.callbacks.beforeNodeAdded(newChild) === false) return;
+                if (ctx.callbacks.beforeNodeAdded(newChild) === false) continue;
 
                 oldParent.insertBefore(newChild, insertionPoint);
                 ctx.callbacks.afterNodeAdded(newChild);

--- a/test/core.js
+++ b/test/core.js
@@ -323,6 +323,23 @@ describe("Core morphing tests", function(){
         document.body.removeChild(parent);
     });
 
+    it.only('can prevent element addition w/ the beforeNodeAdded callback', function() {
+        let parent = make("<div><p>1</p><p>2</p></div>");
+        document.body.append(parent);
+
+        // morph
+        let finalSrc = "<p>1</p><p>2</p><p>3</p><p>4</p>";
+
+        Idiomorph.morph(parent, finalSrc, {morphStyle:'innerHTML', callbacks : {
+            beforeNodeAdded(node) {
+              if(node.outerHTML === "<p>3</p>") return false
+            }
+        }});
+        parent.innerHTML.should.equal("<p>1</p><p>2</p><p>4</p>");
+
+        document.body.removeChild(parent);
+    });
+
     it('ignores active textarea value when ignoreActiveValue is true', function()
     {
         let parent = make("<div><textarea>foo</textarea></div>");


### PR DESCRIPTION
We want to `continue` to progress to the next iteration of `while`, not `return` to break out of the entire function. First commit is a failing test exposing the issue, and second commit is the fix.