### PR TITLE
Add `twoPass` option for additional state retention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,37 @@ jobs:
       - name: Run tests
         run: npm run test-move-before
 
+  test-force-two-pass:
+    runs-on: ubuntu-latest
+    env:
+      DEFAULT_TWO_PASS: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Install browsers
+        run: npx playwright install --with-deps
+      - name: Run tests
+        run: npm run ci
+
+  test-force-two-pass-move-before:
+    runs-on: ubuntu-latest
+    env:
+      DEFAULT_TWO_PASS: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm run test-move-before
+

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Idiomorph supports the following options:
 | `ignoreActiveValue` | If set to `true`, idiomorph will not update the active element's value                                      | `Idiomorph.morph(..., {ignoreActiveValue:true})`                         |
 | `head`              | Allows you to control how the `head` tag is merged.  See the [head](#the-head-tag) section for more details | `Idiomorph.morph(..., {head:{style:merge}})`                             |
 | `callbacks`         | Allows you to insert callbacks when events occur in the morph life cycle, see the callback table below      | `Idiomorph.morph(..., {callbacks:{beforeNodeAdded:function(node){...}})` |
+| `twoPass`           | If set to `true`, idiomorph does a second pass to maintain more state. See [Two Pass Mode](#two-pass-mode)  | `Idiomorph.morph(..., {twoPass:true})`                                   |
 
 #### Callbacks
 
@@ -139,6 +140,15 @@ of the script.
 
 Similarly, you may wish to preserve an element even if it is not in `new`.  You can use the attribute `im-preserve='true'`
 in this case to retain the element.
+
+#### Two Pass Mode
+
+If the `twoPass` option is enabled, Idiomorph will try to maintain more state by temporarily moving some nodes into a
+hidden pantry div. After the initial morph is complete, it runs a second pass, moving the pantried nodes back into the
+document.  These are nodes that would otherwise have been removed and readded, losing identity and state. This is
+particularly useful for reordering morphs involving elements with non-attribute state, e.g. video elements, elements
+preserved with `data-turbo-permanent`, etc. Also, when this option is enabled, Idiomorph will use the upcoming
+`Element#moveBefore` API if it exists, falling back to `Element#insertBefore` if not.
 
 #### Additional Configuration
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ of the algorithm.
 | afterNodeMorphed(oldNode, newNode)                           | Called after a node is morphed in the DOM                                                | none                                               |
 | beforeNodeRemoved(node)                                      | Called before a node is removed from the DOM                                             | return false to not remove the node                |
 | afterNodeRemoved(node)                                       | Called after a node is removed from the DOM                                              | none                                               |
-| beforeAttributeUpdated(attributeName, node, mutationType) | Called before an attribute on an element.  `mutationType` is either "updated" or "removed" | return false to not update or remove the attribute |
+| beforeAttributeUpdated(attributeName, node, mutationType)    | Called before an attribute on an element. `mutationType` is either "updated" or "removed"| return false to not update or remove the attribute |
+| beforeNodePantried(node)                                     | Called before moving the node into the pantry during the second pass (if enabled)        | return false to not move the node into the pantry  |
 
 ### The `head` tag
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -47,6 +47,17 @@ npm run debug
 ```
 This will start the server, and open the test runner in a browser. From there you can choose a test file to run.
 
+## Forcing Two Pass Mode
+If the `DEFAULT_TWO_PASS` environment variable is set before running the tests, Idiomorph will default to two-pass mode. This is useful for running the entire test suite with two-pass on.
+
+## GitHub Actions CI matrix
+On each push and PR, GitHub Actions runs the following test matrix:
+
+1. Normal baseline `npm run ci` run
+2. With experimental moveBefore enabled in the browser
+3. With two-pass mode forced
+4. With both moveBefore enabled and two-pass mode forced
+
 ## Code Coverage Report
 After a test run completes, you can open `coverage/lcov-report/index.html` to view the code coverage report. On Ubuntu you can run:
 ```bash

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -20,6 +20,7 @@
  * @property {function(Element): boolean} [beforeNodeRemoved]
  * @property {function(Element): void} [afterNodeRemoved]
  * @property {function(string, Element, "update" | "remove"): boolean} [beforeAttributeUpdated]
+ * @property {function(Element): boolean} [beforeNodePantried]
  */
 
 /**
@@ -60,6 +61,7 @@
  * @property {(function(Node): boolean) | NoOp} beforeNodeRemoved
  * @property {(function(Node): void) | NoOp} afterNodeRemoved
  * @property {(function(string, Element, "update" | "remove"): boolean) | NoOp} beforeAttributeUpdated
+ * @property {(function(Node): boolean) | NoOp} beforeNodePantried
  */
 
 /**
@@ -131,7 +133,7 @@ var Idiomorph = (function () {
                 beforeNodeRemoved: noOp,
                 afterNodeRemoved: noOp,
                 beforeAttributeUpdated: noOp,
-
+                beforeNodePantried: noOp,
             },
             head: {
                 style: 'merge',
@@ -1115,6 +1117,8 @@ var Idiomorph = (function () {
          * @param {MorphContext} ctx
          */
         function moveToPantry(node, ctx) {
+            if (ctx.callbacks.beforeNodePantried(node) === false) return
+
             Array.from(node.childNodes).forEach(child => {
                 moveToPantry(child, ctx);
             });

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -52,7 +52,7 @@ describe("Bootstrap test", function(){
         print(div1);
 
         // first paragraph should have been discarded in favor of later matches
-        d1.innerHTML.should.equal("A");
+        d1.innerHTML.should.not.equal("D");
 
         // second and third paragraph should have morphed
         d2.innerHTML.should.equal("E");

--- a/test/two-pass.js
+++ b/test/two-pass.js
@@ -1,0 +1,355 @@
+describe("Two-pass option for retaining more state", function(){
+
+    beforeEach(function() {
+        clearWorkArea();
+    });
+
+    it('fails to preserve all non-attribute element state with single-pass option', function()
+    {
+        getWorkArea().append(make(`
+            <div>
+              <input type="checkbox" id="first">
+              <input type="checkbox" id="second">
+            </div>
+        `));
+        document.getElementById("first").indeterminate = true
+        document.getElementById("second").indeterminate = true
+
+        let finalSrc = `
+            <div>
+              <input type="checkbox" id="second">
+              <input type="checkbox" id="first">
+            </div>
+        `;
+        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML', twoPass:false});
+
+        getWorkArea().innerHTML.should.equal(finalSrc);
+        const states = Array.from(getWorkArea().querySelectorAll("input")).map(e => e.indeterminate);
+        states.should.eql([true, false]);
+    });
+
+    it('preserves all non-attribute element state with two-pass option', function()
+    {
+        getWorkArea().append(make(`
+            <div>
+              <input type="checkbox" id="first">
+              <input type="checkbox" id="second">
+            </div>
+        `));
+        document.getElementById("first").indeterminate = true
+        document.getElementById("second").indeterminate = true
+
+        let finalSrc = `
+            <div>
+              <input type="checkbox" id="second">
+              <input type="checkbox" id="first">
+            </div>
+        `;
+        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true});
+
+        getWorkArea().innerHTML.should.equal(finalSrc);
+        const states = Array.from(getWorkArea().querySelectorAll("input")).map(e => e.indeterminate);
+        states.should.eql([true, true]);
+    });
+
+    it('preserves all non-attribute element state with two-pass option and outerHTML morphStyle', function()
+    {
+        const div = make(`
+            <div>
+              <input type="checkbox" id="first">
+              <input type="checkbox" id="second">
+            </div>
+        `);
+        getWorkArea().append(div);
+        document.getElementById("first").indeterminate = true
+        document.getElementById("second").indeterminate = true
+
+        let finalSrc = `
+            <div>
+              <input type="checkbox" id="second">
+              <input type="checkbox" id="first">
+            </div>
+        `;
+        Idiomorph.morph(div, finalSrc, {morphStyle:'outerHTML',twoPass:true});
+
+        getWorkArea().innerHTML.should.equal(finalSrc);
+        const states = Array.from(getWorkArea().querySelectorAll("input")).map(e => e.indeterminate);
+        states.should.eql([true, true]);
+    });
+
+    it('preserves non-attribute state when elements are moved to different levels of the DOM', function()
+    {
+        getWorkArea().append(make(`
+            <div>
+              <input type="checkbox" id="first">
+              <div>
+                <input type="checkbox" id="second">
+              </div>
+            </div>
+        `));
+        document.getElementById("first").indeterminate = true
+        document.getElementById("second").indeterminate = true
+
+        let finalSrc = `
+            <div>
+              <input type="checkbox" id="first">
+              <input type="checkbox" id="second">
+            </div>
+        `;
+        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true});
+
+        getWorkArea().innerHTML.should.equal(finalSrc);
+        const states = Array.from(getWorkArea().querySelectorAll("input")).map(e => e.indeterminate);
+        states.should.eql([true, true]);
+    });
+
+    it('preserves non-attribute state when elements are moved between different containers', function()
+    {
+        getWorkArea().append(make(`
+            <div>
+              <div id="left">
+                <input type="checkbox" id="first">
+              </div>
+              <div id="right">
+                <input type="checkbox" id="second">
+              </div>
+            </div>
+        `));
+        document.getElementById("first").indeterminate = true
+        document.getElementById("second").indeterminate = true
+
+        let finalSrc = `
+            <div>
+              <div id="left">
+                <input type="checkbox" id="second">
+              </div>
+              <div id="right">
+                <input type="checkbox" id="first">
+              </div>
+            </div>
+        `;
+        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true});
+
+        getWorkArea().innerHTML.should.equal(finalSrc);
+        const states = Array.from(getWorkArea().querySelectorAll("input")).map(e => e.indeterminate);
+        states.should.eql([true, true]);
+    });
+
+    it('preserves non-attribute state when parents are reorderd', function()
+    {
+        getWorkArea().append(make(`
+            <div>
+              <div id="left">
+                <input type="checkbox" id="first">
+              </div>
+              <div id="right">
+                <input type="checkbox" id="second">
+              </div>
+            </div>
+        `));
+        document.getElementById("first").indeterminate = true
+        document.getElementById("second").indeterminate = true
+
+        let finalSrc = `
+            <div>
+              <div id="right">
+                <input type="checkbox" id="second">
+              </div>
+              <div id="left">
+                <input type="checkbox" id="first">
+              </div>
+            </div>
+        `;
+        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true});
+
+        getWorkArea().innerHTML.should.equal(finalSrc);
+        const states = Array.from(getWorkArea().querySelectorAll("input")).map(e => e.indeterminate);
+        states.should.eql([true, true]);
+    });
+
+    it('preserves focus state with two-pass option and outerHTML morphStyle', function()
+    {
+        const div = make(`
+            <div>
+              <input type="text" id="first">
+              <input type="text" id="second">
+            </div>
+        `);
+        getWorkArea().append(div);
+        document.getElementById("first").focus()
+
+        let finalSrc = `
+            <div>
+              <input type="text" id="second">
+              <input type="text" id="first">
+            </div>
+        `;
+        Idiomorph.morph(div, finalSrc, {morphStyle:'outerHTML',twoPass:true});
+
+        getWorkArea().innerHTML.should.equal(finalSrc);
+        if(document.body.moveBefore) {
+          document.activeElement.outerHTML.should.equal(document.getElementById("first").outerHTML);
+        } else {
+          document.activeElement.outerHTML.should.equal(document.body.outerHTML);
+          console.log('preserves focus state with two-pass option and outerHTML morphStyle test needs moveBefore enabled to work properly')
+        }
+    });
+
+    it('preserves focus state when elements are moved to different levels of the DOM', function()
+    {
+        getWorkArea().append(make(`
+            <div>
+              <input type="text" id="first">
+              <div>
+                <input type="text" id="second">
+              </div>
+            </div>
+        `));
+        document.getElementById("second").focus()
+
+        let finalSrc = `
+            <div>
+              <input type="text" id="first">
+              <input type="text" id="second">
+            </div>
+        `;
+        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true});
+
+        getWorkArea().innerHTML.should.equal(finalSrc);
+        if(document.body.moveBefore) {
+          document.activeElement.outerHTML.should.equal(document.getElementById("second").outerHTML);
+        } else {
+          document.activeElement.outerHTML.should.equal(document.body.outerHTML);
+          console.log('preserves focus state when elements are moved to different levels of the DOM test needs moveBefore enabled to work properly')
+        }
+    });
+
+    it('preserves focus state when elements are moved between different containers', function()
+    {
+        getWorkArea().append(make(`
+            <div>
+              <div id="left">
+                <input type="text" id="first">
+              </div>
+              <div id="right">
+                <input type="text" id="second">
+              </div>
+            </div>
+        `));
+        document.getElementById("first").focus()
+
+        let finalSrc = `
+            <div>
+              <div id="left">
+                <input type="text" id="second">
+              </div>
+              <div id="right">
+                <input type="text" id="first">
+              </div>
+            </div>
+        `;
+        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true});
+
+        getWorkArea().innerHTML.should.equal(finalSrc);
+        if(document.body.moveBefore) {
+          document.activeElement.outerHTML.should.equal(document.getElementById("first").outerHTML);
+        } else {
+          document.activeElement.outerHTML.should.equal(document.body.outerHTML);
+          console.log('preserves focus state when elements are moved between different containers test needs moveBefore enabled to work properly')
+        }
+    });
+
+    it('preserves focus state when parents are reorderd', function()
+    {
+        getWorkArea().append(make(`
+            <div>
+              <div id="left">
+                <input type="text" id="first">
+              </div>
+              <div id="right">
+                <input type="text" id="second">
+              </div>
+            </div>
+        `));
+        document.getElementById("first").focus()
+
+        let finalSrc = `
+            <div>
+              <div id="right">
+                <input type="text" id="second">
+              </div>
+              <div id="left">
+                <input type="text" id="first">
+              </div>
+            </div>
+        `;
+        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true});
+
+        getWorkArea().innerHTML.should.equal(finalSrc);
+        if(document.body.moveBefore) {
+          document.activeElement.outerHTML.should.equal(document.getElementById("first").outerHTML);
+        } else {
+          document.activeElement.outerHTML.should.equal(document.body.outerHTML);
+          console.log('preserves focus state when parents are reorderd test needs moveBefore enabled to work properly')
+        }
+    });
+
+    it('hooks work as expected', function()
+    {
+        let beginSrc =`
+            <div>
+              <input type="checkbox" id="first">
+              <input type="checkbox" id="second">
+            </div>
+        `.trim();
+        getWorkArea().append(make(beginSrc));
+
+        let finalSrc = `
+            <div>
+              <input type="checkbox" id="second">
+              <input type="checkbox" id="first">
+            </div>
+        `.trim();
+
+        let wrongHookCalls = [];
+        let wrongHookHandler = name => {
+            return node => {
+                if (node.nodeType !== Node.ELEMENT_NODE) return;
+                wrongHookCalls.push([name, node.outerHTML]);
+            }
+        }
+
+        let calls = [];
+
+        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true,callbacks:{
+            beforeNodeAdded: wrongHookHandler("beforeNodeAdded"),
+            afterNodeAdded: wrongHookHandler("afterNodeAdded"),
+            beforeNodeRemoved: wrongHookHandler("beforeNodeRemoved"),
+            afterNodeRemoved: wrongHookHandler("afterNodeRemoved"),
+            beforeNodeMorphed: (oldNode, newNode) => {
+                if (oldNode.nodeType !== Node.ELEMENT_NODE) return;
+                calls.push(["before", oldNode.outerHTML, newNode.outerHTML]);
+            },
+            afterNodeMorphed: (oldNode, newNode) => {
+                if (oldNode.nodeType !== Node.ELEMENT_NODE) return;
+                calls.push(["after", oldNode.outerHTML, newNode.outerHTML]);
+            },
+        }});
+
+        getWorkArea().innerHTML.should.equal(finalSrc);
+
+        wrongHookCalls.should.eql([]);
+        calls.should.eql([
+            ["before", beginSrc, finalSrc],
+            ["before", `<input type="checkbox" id="second">`, `<input type="checkbox" id="second">`],
+            ["after", `<input type="checkbox" id="second">`, `<input type="checkbox" id="second">`],
+            ["after",
+              finalSrc,
+              "<div>\n              <input type=\"checkbox\" id=\"second\">\n              </div>",
+            ],
+            ["before", `<input type="checkbox" id="first">`, `<input type="checkbox" id="first">`],
+            ["after", `<input type="checkbox" id="first">`, `<input type="checkbox" id="first">`],
+        ]);
+
+    });
+});

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -22,6 +22,7 @@ let config = {
       </script>
 
       <script src="/src/idiomorph.js"></script>
+      <script>Idiomorph.defaults.twoPass = ${process.env.DEFAULT_TWO_PASS}</script>
 
       <script src="/node_modules/htmx.org/dist/htmx.js"></script>
       <script src="/src/idiomorph-htmx.js"></script>


### PR DESCRIPTION
# Add Two-Pass option for retaining additional element state

Superseeds #61. Read that for more context, but the gist of it is that this is a stop-gap solution for retaining more element state within morphs until `moveBefore` lands in browsers.

This draft PR is just an initial spike, so there are some missing pieces that I'd like to resolve before considering this ready for merge:
1. Only works with `morphStyle: innerHTML`
2. `moveBefore` support is still missing
3. Only tested in a super basic scenario where it successfully maintains checkbox indeterminate state

What else? Any other thoughts about this direction?