### PR TITLE
Add tests to cover hooks, and fix extraneous hook call

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -439,10 +439,10 @@ var Idiomorph = (function () {
                 // iterate backwards to avoid skipping over items when a delete occurs
                 for (let i = toAttributes.length - 1; 0 <= i; i--) {
                     const toAttribute = toAttributes[i];
-                    if (ignoreAttribute(toAttribute.name, toEl, 'remove', ctx)) {
-                        continue;
-                    }
                     if (!fromEl.hasAttribute(toAttribute.name)) {
+                        if (ignoreAttribute(toAttribute.name, toEl, 'remove', ctx)) {
+                            continue;
+                        }
                         toEl.removeAttribute(toAttribute.name);
                     }
                 }

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,0 +1,178 @@
+describe("lifecycle hooks", function(){
+    beforeEach(function() {
+        clearWorkArea();
+    });
+
+    it('calls beforeNodeAdded before a new node is added to the DOM', function(){
+        let calls = [];
+        let initial = make("<ul><li>A</li></ul>");
+        Idiomorph.morph(initial, "<ul><li>A</li><li>B</li></ul>", { callbacks: {
+            beforeNodeAdded: node => {
+                calls.push(node.outerHTML);
+            }
+        } });
+        initial.outerHTML.should.equal("<ul><li>A</li><li>B</li></ul>");
+        calls.should.eql(["<li>B</li>"]);
+    });
+
+    it('returning false to beforeNodeAdded prevents adding the node', function(){
+        let initial = make("<ul><li>A</li></ul>");
+        Idiomorph.morph(initial, "<ul><li>A</li><li>B</li></ul>", { callbacks: {
+            beforeNodeAdded: node => false,
+        } });
+        initial.outerHTML.should.equal("<ul><li>A</li></ul>");
+    });
+
+    it('calls afterNodeAdded after a new node is added to the DOM', function(){
+        let calls = [];
+        let initial = make("<ul><li>A</li></ul>");
+        Idiomorph.morph(initial, "<ul><li>A</li><li>B</li></ul>", { callbacks: {
+            afterNodeAdded: node => {
+                calls.push(node.outerHTML);
+            }
+        } });
+        initial.outerHTML.should.equal("<ul><li>A</li><li>B</li></ul>");
+        calls.should.eql(["<li>B</li>"]);
+    });
+
+    it('calls beforeNodeMorphed before a node is morphed', function(){
+        let calls = [];
+        let initial = make(`<ul><li id="a">A</li></ul>`);
+        Idiomorph.morph(initial, `<ul><li id="a">B</li></ul>`, { callbacks: {
+            beforeNodeMorphed: (oldNode, newNode) => {
+                calls.push([
+                  oldNode.outerHTML || oldNode.textContent,
+                  newNode.outerHTML || newNode.textContent,
+                ]);
+            }
+        } });
+        initial.outerHTML.should.equal(`<ul><li id="a">B</li></ul>`);
+        calls.should.eql([
+          [`<ul><li id="a">A</li></ul>`, `<ul><li id="a">B</li></ul>`],
+          [`<li id="a">A</li>`, `<li id="a">B</li>`],
+          [`A`, `B`],
+        ]);
+    });
+
+    it('returning false to beforeNodeMorphed prevents morphing the node', function(){
+        let initial = make(`<ul name="a"><li name="a" id="a">A</li></ul>`);
+        Idiomorph.morph(initial, `<ul name="b"><li name="b" id="a">B</li></ul>`, { callbacks: {
+            beforeNodeMorphed: node => {
+              if(node.nodeType === Node.TEXT_NODE) return false
+            }
+        } })
+        initial.outerHTML.should.equal(`<ul name="b"><li name="b" id="a">A</li></ul>`);
+    });
+
+    it.skip('calls afterNodeMorphed before a node is morphed', function(){
+        let calls = [];
+        let initial = make(`<ul><li id="a">A</li></ul>`);
+        Idiomorph.morph(initial, `<ul><li id="a">B</li></ul>`, { callbacks: {
+            afterNodeMorphed: (oldNode, newNode) => {
+                calls.push([
+                  oldNode.outerHTML || oldNode.textContent,
+                  newNode.outerHTML || newNode.textContent,
+                ]);
+            }
+        } });
+        initial.outerHTML.should.equal(`<ul><li id="a">B</li></ul>`);
+        calls.should.eql([
+          [`A`, `B`],
+          [`<li id="a">A</li>`, `<li id="a">B</li>`],
+          [`<ul><li id="a">A</li></ul>`, `<ul><li id="a">B</li></ul>`],
+        ]);
+    });
+
+    it('calls beforeNodeRemoved before a node is removed from the DOM', function(){
+        let calls = [];
+        let initial = make("<ul><li>A</li><li>B</li></ul>");
+        Idiomorph.morph(initial, "<ul><li>A</li></ul>", { callbacks: {
+            beforeNodeRemoved: node => {
+                calls.push(node.outerHTML);
+            }
+        } });
+        initial.outerHTML.should.equal("<ul><li>A</li></ul>");
+        calls.should.eql(["<li>B</li>"]);
+    });
+
+    it('returning false to beforeNodeRemoved prevents removing the node', function(){
+        let initial = make("<ul><li>A</li><li>B</li></ul>");
+        Idiomorph.morph(initial, "<ul><li>A</li></ul>", { callbacks: {
+            beforeNodeRemoved: node => false,
+        } });
+        initial.outerHTML.should.equal("<ul><li>A</li><li>B</li></ul>");
+    });
+
+    it('calls afterNodeRemoved after a node is removed from the DOM', function(){
+        let calls = [];
+        let initial = make("<ul><li>A</li><li>B</li></ul>");
+        Idiomorph.morph(initial, "<ul><li>A</li></ul>", { callbacks: {
+            afterNodeRemoved: node => {
+                calls.push(node.outerHTML);
+            }
+        } });
+        initial.outerHTML.should.equal("<ul><li>A</li></ul>");
+        calls.should.eql(["<li>B</li>"]);
+    });
+
+    it.skip('calls beforeAttributeUpdated when an attribute is added', function(){
+        let calls = [];
+        let initial = make("<a></a>");
+        Idiomorph.morph(initial, `<a href="#"></a>`, { callbacks: {
+            beforeAttributeUpdated: (attributeName, node, mutationType) => {
+                calls.push([attributeName, node.outerHTML, mutationType]);
+            }
+        } });
+        initial.outerHTML.should.equal(`<a href="#"></a>`);
+        calls.should.eql([["href", `<a></a>`, "update"]]);
+    });
+
+    it.skip('calls beforeAttributeUpdated when an attribute is updated', function(){
+        let calls = [];
+        let initial = make(`<a href="a"></a>`);
+        Idiomorph.morph(initial, `<a href="b"></a>`, { callbacks: {
+            beforeAttributeUpdated: (attributeName, node, mutationType) => {
+                calls.push([attributeName, node.outerHTML, mutationType]);
+            }
+        } });
+        initial.outerHTML.should.equal(`<a href="b"></a>`);
+        calls.should.eql([["href", `<a href="a"></a>`, "update"]]);
+    });
+
+    it('calls beforeAttributeUpdated when an attribute is removed', function(){
+        let calls = [];
+        let initial = make(`<a href="#"></a>`);
+        Idiomorph.morph(initial, `<a></a>`, { callbacks: {
+            beforeAttributeUpdated: (attributeName, node, mutationType) => {
+                calls.push([attributeName, node.outerHTML, mutationType]);
+            }
+        } });
+        initial.outerHTML.should.equal(`<a></a>`);
+        calls.should.eql([["href", `<a href="#"></a>`, "remove"]]);
+    });
+
+    it('returning false to beforeAttributeUpdated prevents the attribute addition', function(){
+        let initial = make("<a></a>");
+        Idiomorph.morph(initial, `<a href="#"></a>`, { callbacks: {
+            beforeAttributeUpdated: () => false,
+        } });
+        initial.outerHTML.should.equal(`<a></a>`);
+    });
+
+    it('returning false to beforeAttributeUpdated prevents the attribute update', function(){
+        let initial = make(`<a href="a"></a>`);
+        Idiomorph.morph(initial, `<a href="b"></a>`, { callbacks: {
+            beforeAttributeUpdated: () => false,
+        } });
+        initial.outerHTML.should.equal(`<a href="a"></a>`);
+    });
+
+    it('returning false to beforeAttributeUpdated prevents the attribute removal', function(){
+        let initial = make(`<a href="#"></a>`);
+        Idiomorph.morph(initial, `<a></a>`, { callbacks: {
+            beforeAttributeUpdated: () => false,
+        } });
+        initial.outerHTML.should.equal(`<a href="#"></a>`);
+    });
+});
+

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -64,7 +64,7 @@ describe("lifecycle hooks", function(){
         initial.outerHTML.should.equal(`<ul name="b"><li name="b" id="a">A</li></ul>`);
     });
 
-    it.skip('calls afterNodeMorphed before a node is morphed', function(){
+    it('calls afterNodeMorphed before a node is morphed', function(){
         let calls = [];
         let initial = make(`<ul><li id="a">A</li></ul>`);
         Idiomorph.morph(initial, `<ul><li id="a">B</li></ul>`, { callbacks: {
@@ -77,9 +77,9 @@ describe("lifecycle hooks", function(){
         } });
         initial.outerHTML.should.equal(`<ul><li id="a">B</li></ul>`);
         calls.should.eql([
-          [`A`, `B`],
-          [`<li id="a">A</li>`, `<li id="a">B</li>`],
-          [`<ul><li id="a">A</li></ul>`, `<ul><li id="a">B</li></ul>`],
+          [`B`, `B`],
+          [`<li id="a">B</li>`, `<li id="a">B</li>`],
+          [`<ul><li id="a">B</li></ul>`, `<ul><li id="a">B</li></ul>`],
         ]);
     });
 

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -115,7 +115,7 @@ describe("lifecycle hooks", function(){
         calls.should.eql(["<li>B</li>"]);
     });
 
-    it.skip('calls beforeAttributeUpdated when an attribute is added', function(){
+    it('calls beforeAttributeUpdated when an attribute is added', function(){
         let calls = [];
         let initial = make("<a></a>");
         Idiomorph.morph(initial, `<a href="#"></a>`, { callbacks: {
@@ -127,7 +127,7 @@ describe("lifecycle hooks", function(){
         calls.should.eql([["href", `<a></a>`, "update"]]);
     });
 
-    it.skip('calls beforeAttributeUpdated when an attribute is updated', function(){
+    it('calls beforeAttributeUpdated when an attribute is updated', function(){
         let calls = [];
         let initial = make(`<a href="a"></a>`);
         Idiomorph.morph(initial, `<a href="b"></a>`, { callbacks: {


### PR DESCRIPTION
There were no tests at all for the hooks, and hooks are about to get weird with the upcoming twoPass system, so I thought I'd add some to cover the status quo! However, this unearthed some bugs and questions.

So, three commits here:
1. First one is covering all the hook behavior, as I expected it to work, based off the README. I had to mark three tests as `skip`, because...
2. The `beforeAttributeUpdated` hook was erroneously getting called twice on additions and updates, with the second call claiming a `remove` mutation, which was definitely not happening. The change to the `src` in this PR is reflecting that fix.
3. In the last commit I change the test from what I expected the behavior to be, to what it actually is. In short, `afterNodeMorphed(oldNode, newContent)` is being called with BOTH arguments essentially being the same. On one hand, this is surprising. I'd naively expect it to show me the before and after states, especially given the argument names. However, since the first argument is the node itself, and its _after_ it's been morphed, it does make some sense for both arguments to be the same. So, is this a bug, or desired behavior? Maybe we just need to change the names of the arguments? Or just pass one `(node)` argument?

Lastly, two questions:
1. I notice that all events have a before and after hook, except for the attribute update event, which only has a `beforeAttributeUpdated` event. Should we add a corresponding `afterAttributeUpdated` event? Pushing this to its logical conclusion, it would be easy to imagine expanding this to `AttributeAdded` `AttributeUpdated` and `AttributeRemoved`, as well. Has any downstream software ever wanted any of these? 
2. Looking at the arguments for `beforeAttributeUpdated`, I expected to see the value of the attribute in there, but I do not, just the name. Should we add it?