### PR TITLE
Test suite improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,17 @@ jobs:
       - name: Run tests
         run: npm run ci
 
+  test-move-before:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm run test-move-before
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /coverage
+/test/chrome-profile
 .idea

--- a/TESTING.md
+++ b/TESTING.md
@@ -25,6 +25,12 @@ npm run ci
 ```
 This will run the tests using Playwright’s headless browser setup across Chrome, Firefox, and WebKit (Safari-adjacent). This is ultimately what gets run in Github Actions to verify PRs.
 
+To run all tests against Chrome with experimental `moveBefore` support added, execute:
+```bash
+npm run test-move-before
+```
+This will start headless Chrome in a new profile with the `atomic-move` experimental flag set. This runs in a separate job in CI.
+
 ## Running Individual Tests
 
 ### Headless Mode

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "test": "web-test-runner",
     "debug": "web-test-runner --manual --open",
+    "test-move-before": "USE_MOVE_BEFORE=1 web-test-runner",
     "ci": "web-test-runner --playwright --browsers chromium firefox webkit",
     "amd": "(echo \"define(() => {\n\" && cat src/idiomorph.js && echo \"\nreturn Idiomorph});\") > dist/idiomorph.amd.js",
     "cjs": "(cat src/idiomorph.js && echo \"\nmodule.exports = Idiomorph;\") > dist/idiomorph.cjs.js",

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1,10 +1,6 @@
 describe("Bootstrap test", function(){
+    setup();
 
-    beforeEach(function() {
-        clearWorkArea();
-    });
-
-    // bootstrap test
     it('can morph content to content', function()
     {
         let btn1 = make('<button>Foo</button>')

--- a/test/core.js
+++ b/test/core.js
@@ -1,8 +1,5 @@
 describe("Core morphing tests", function(){
-
-    beforeEach(function() {
-        clearWorkArea();
-    });
+    setup();
 
     it('morphs outerHTML as content properly when argument is null', function()
     {
@@ -459,6 +456,5 @@ describe("Core morphing tests", function(){
             Idiomorph.defaults.morphStyle = 'outerHTML';
         }
     });
-
 
 })

--- a/test/fidelity.js
+++ b/test/fidelity.js
@@ -1,8 +1,5 @@
 describe("Tests to ensure that idiomorph merges properly", function(){
-
-    beforeEach(function() {
-        clearWorkArea();
-    });
+    setup();
 
     function expectFidelity(actual, expected) {
         if (actual.outerHTML !== expected) {

--- a/test/head.js
+++ b/test/head.js
@@ -1,8 +1,5 @@
 describe("Tests to ensure that the head tag merging works correctly", function() {
-
-    beforeEach(function () {
-        clearWorkArea();
-    });
+    setup();
 
     it('adds a new element correctly', function () {
         let parser = new DOMParser();

--- a/test/htmx-integration.js
+++ b/test/htmx-integration.js
@@ -1,5 +1,4 @@
 describe("Tests for the htmx integration", function() {
-
     function makeServer(){
         var server = sinon.fakeServer.create();
         htmx.config.defaultSettleDelay = 0;

--- a/test/lib/utilities.js
+++ b/test/lib/utilities.js
@@ -1,4 +1,9 @@
 /* Test Utilities */
+function setup() {
+    beforeEach(function() {
+        clearWorkArea();
+    });
+}
 
 function make(htmlStr) {
     let range = document.createRange();

--- a/test/lib/utilities.js
+++ b/test/lib/utilities.js
@@ -1,6 +1,10 @@
 /* Test Utilities */
+
 function setup() {
-    beforeEach(function() {
+    beforeEach(() => {
+        if (window.useMoveBefore && !Element.prototype.moveBefore) {
+            throw new Error('Element.prototype.moveBefore is not available.');
+        }
         clearWorkArea();
     });
 }

--- a/test/perf.js
+++ b/test/perf.js
@@ -1,9 +1,5 @@
 describe("Tests to compare perf with morphdom", function(){
-
-    beforeEach(function() {
-        clearWorkArea();
-    });
-
+    setup();
 
     it('HTML5 Elements Sample Page', function(done)
     {

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -1,6 +1,9 @@
 export default {
   nodeResolve: true,
   coverage: true,
+  coverageConfig: {
+    include: ['src/**/*'],
+  },
   files: "test/*.js",
   testRunnerHtml: (testFramework) => `
     <!DOCTYPE html>

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -1,17 +1,17 @@
-export default {
-  nodeResolve: true,
-  coverage: true,
-  coverageConfig: {
-    include: ['src/**/*'],
-  },
-  files: "test/*.js",
+import { chromeLauncher } from "@web/test-runner";
+import { exec } from "child_process";
+
+let config = {
   testRunnerHtml: (testFramework) => `
     <!DOCTYPE html>
     <html>
     <head>
       <script src="/node_modules/chai/chai.js"></script>
       <script src="/node_modules/chai-dom/chai-dom.js"></script>
-      <script>should = chai.should()</script>
+      <script>
+          should = chai.should();
+          window.useMoveBefore = ${process.env.USE_MOVE_BEFORE};
+      </script>
       <script src="/test/lib/utilities.js"></script>
       <script src="/node_modules/sinon/pkg/sinon.js"></script>
 
@@ -32,5 +32,25 @@ export default {
     </body>
     </html>
   `,
+
+  nodeResolve: true,
+  coverage: true,
+  coverageConfig: {
+    include: ['src/**/*'],
+  },
+  files: "test/*.js",
 };
 
+if (process.env.USE_MOVE_BEFORE) {
+  // configure chrome to use a custom profile directory we control
+  config.browsers = [
+    chromeLauncher({ launchOptions: { args: ['--user-data-dir=test/chrome-profile'] } })
+  ]
+  exec([
+    'rm -rf test/chrome-profile', // clear profile out from last run
+    'mkdir -p test/chrome-profile', // create from scratch
+    `echo '{"browser":{"enabled_labs_experiments":["atomic-move@1"]}}' > test/chrome-profile/Local\\ State`, // enable experiment
+  ].join(" && "));
+}
+
+export default config;


### PR DESCRIPTION
Some test suite improvements. Three commits:

1. Code coverage was covering things we didn't care about, like the morphdom source in test/lib. Set it to only cover files in src/.
2. Extract the duplicated: `beforeEach(function() { clearWorkArea(); });` in each test file to just a single `setup()` call. This also comes in handy for...
3. Add `npm test-move-before` for running the tests in a browser with `Element#moveBefore` enabled. This was a bit tricky to do! Details below:

Ideally it'd just be a separate browser run in the main CI job, but it was surprisingly difficult to get a browser with the chrome://flags/#atomic-move experiment enabled. You can't enable it at runtime, the browser needs to boot up with that flag already enabled for it work. But there's no command-line flag to do so! The only way I could figure out how to do this was to dig into the on-disk Chrome profile and manually munge in the setting. So its currently a separate npm script: npm run test-move-before, and this is run as a separate job in the GitHub Actions CI.

In addition I've added a line to `setup()` that fails the test if the browser is expected to respond to `moveBefore` but doesn't, just to make sure we're testing what we think we're testing in that run.