### PR TITLE
Fix persistent ids being softMatched when they shouldn't

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -1204,15 +1204,17 @@ var Idiomorph = (function () {
          * @returns {Set<string>} the id set of all persistent nodes that exist in both old and new content
          */
         function persistentIdSet(oldContent, newContent) {
-            let idSet = new Set();
+            let matchIdSet = new Set();
+            let oldIdSet = new Set();
             for (const oldNode of nodesWithIds(oldContent)) {
-                for (const newNode of nodesWithIds(newContent)) {
-                    if (oldNode.id === newNode.id) {
-                        idSet.add(oldNode.id);
-                    }
+                oldIdSet.add(oldNode.id);
+            }
+            for (const newNode of nodesWithIds(newContent)) {
+                if (oldIdSet.has(newNode.id)) {
+                    matchIdSet.add(newNode.id);
                 }
             }
-            return idSet;
+            return matchIdSet;
         }
 
         //=============================================================================

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -1207,10 +1207,10 @@ var Idiomorph = (function () {
             let matchIdSet = new Set();
             let oldIdSet = new Set();
             for (const oldNode of nodesWithIds(oldContent)) {
-                oldIdSet.add(oldNode.id);
+                oldIdSet.add(oldNode.id+':'+oldNode.tagName);
             }
             for (const newNode of nodesWithIds(newContent)) {
-                if (oldIdSet.has(newNode.id)) {
+                if (oldIdSet.has(newNode.id+':'+newNode.tagName)) {
                     matchIdSet.add(newNode.id);
                 }
             }

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -1136,6 +1136,18 @@ var Idiomorph = (function () {
         }
 
         /**
+         * @param {Element} Content Content containing id's
+         * @returns {Node[]} all nodes that have id's
+         */
+        function nodesWithIds(Content) {
+            let Nodes = Array.from(Content.querySelectorAll('[id]'));
+            if(Content.id) {
+               Nodes.push(Content);
+            }
+            return Nodes;
+        }
+
+        /**
          * A bottom up algorithm that finds all elements with ids in the node
          * argument and populates id sets for those nodes and all their parents, generating
          * a set of ids contained within all nodes for the entire hierarchy in the DOM
@@ -1145,12 +1157,7 @@ var Idiomorph = (function () {
          */
         function populateIdMapForNode(node, idMap) {
             let nodeParent = node.parentElement;
-            // find all inside elements with an id property
-            let idElements = Array.from(node.querySelectorAll('[id]'));
-            if (node.id) {
-                idElements.push(node) // also include the node itself
-            }
-            for (const elt of idElements) {
+            for (const elt of nodesWithIds(node)) {
                 /**
                  * @type {Element|null}
                  */
@@ -1194,12 +1201,12 @@ var Idiomorph = (function () {
         /**
          * @param {Element} oldContent  the old content that will be morphed
          * @param {Element} newContent  the new content to morph to
-         * @returns {Set<string>} the set of all persistent nodes that exist in both old and new content
+         * @returns {Set<string>} the id set of all persistent nodes that exist in both old and new content
          */
         function persistentIdSet(oldContent, newContent) {
             let idSet = new Set();
-            for (const oldNode of oldContent.querySelectorAll('[id]')) {
-                for (const newNode of newContent.querySelectorAll('[id]')) {
+            for (const oldNode of nodesWithIds(oldContent)) {
+                for (const newNode of nodesWithIds(newContent)) {
                     if (oldNode.id === newNode.id) {
                         idSet.add(oldNode.id);
                     }

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -1136,8 +1136,8 @@ var Idiomorph = (function () {
         }
 
         /**
-         * @param {Element} Content Content containing id's
-         * @returns {Element[]} all nodes that have id's
+         * @param {Element} Content
+         * @returns {Element[]}
          */
         function nodesWithIds(Content) {
             let Nodes = Array.from(Content.querySelectorAll('[id]'));

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -1137,7 +1137,7 @@ var Idiomorph = (function () {
 
         /**
          * @param {Element} Content Content containing id's
-         * @returns {Node[]} all nodes that have id's
+         * @returns {Element[]} all nodes that have id's
          */
         function nodesWithIds(Content) {
             let Nodes = Array.from(Content.querySelectorAll('[id]'));

--- a/test/core.js
+++ b/test/core.js
@@ -320,7 +320,7 @@ describe("Core morphing tests", function(){
         document.body.removeChild(parent);
     });
 
-    it.only('can prevent element addition w/ the beforeNodeAdded callback', function() {
+    it('can prevent element addition w/ the beforeNodeAdded callback', function() {
         let parent = make("<div><p>1</p><p>2</p></div>");
         document.body.append(parent);
 

--- a/test/core.js
+++ b/test/core.js
@@ -320,7 +320,7 @@ describe("Core morphing tests", function(){
         document.body.removeChild(parent);
     });
 
-    it('can prevent element addition w/ the beforeNodeAdded callback', function() {
+    it.only('can prevent element addition w/ the beforeNodeAdded callback', function() {
         let parent = make("<div><p>1</p><p>2</p></div>");
         document.body.append(parent);
 
@@ -474,4 +474,35 @@ describe("Core morphing tests", function(){
         }
     });
 
+    it('non-attribute state of element with id is not transfered to other elements when moved between different containers', function()
+    {
+        getWorkArea().append(make(`
+            <div>
+              <div id="left">
+                <input type="checkbox" id="first">
+              </div>
+              <div id="right">
+                <input type="checkbox" id="second">
+              </div>
+            </div>
+        `));
+        document.getElementById("first").indeterminate = true
+
+        let finalSrc = `
+            <div>
+              <div id="left">
+                <input type="checkbox" id="second">
+              </div>
+              <div id="right">
+                <input type="checkbox" id="first">
+              </div>
+            </div>
+        `;
+        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML'});
+
+        getWorkArea().innerHTML.should.equal(finalSrc);
+        // second checkbox is now in firsts place and we don't want firsts indeterminate state to be retained
+        // on what is now the second element so we need to prevent softMatch mroph from matching persistent id's
+        document.getElementById("second").indeterminate.should.eql(false)
+    });
 })


### PR DESCRIPTION
during the work testing two-step we found that it is soft matching when an id is swapped around to a different location during the morph.  Even though the id exists in both the old and new content it can be moved to a different location and when this happens it can detect two elements as softMatches and morph them in place which can transfer hidden state like intermediate checkbox state or focus to an item with a different ID which is not ideal.  

So to resolve this I've created a new persistenIds global set with a new routine that finds all id's that match between old and new content.  When checking for soft Matches it can then use this set of id's and exclude from soft matching when the id's are not exactly the same and either of the id's is in the persistent id set. 

To test this works as expected I pulled in all the two-pass tests and code as well and tested to make sure it passed the tests without needing workarounds.

I also found core tests were accidently left disabled so removed the only.  But removed the fix for this so it can be done in another PR

Finally I found while testing that populateIdMapForNode was not working as you would expect as sometimes the oldContent node passed in can contain an ID and it only processed this nodes children via the querySelectorAll leaving possible bugs as the parent node's ID is never added into the set.  the documentation for createIdMap() lower down says it should be inclusive of the Node.  So I wrote a quick helper funciton to get all Nodes with ID's including self which is used 3 times.