### PR TITLE
Add `--fail-only` option to fail the test suite in CI when an `it.only` is left in

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -23,7 +23,7 @@ To run all tests against all browsers in headless mode, execute:
 ```bash
 npm run ci
 ```
-This will run the tests using Playwright’s headless browser setup across Chrome, Firefox, and WebKit (Safari-adjacent). This is ultimately what gets run in Github Actions to verify PRs.
+This will run the tests using Playwright’s headless browser setup across Chrome, Firefox, and WebKit (Safari-adjacent). This is ultimately what gets run in Github Actions to verify PRs. This build will fail if there is an `it.only` left in the codebase, thanks to a custom `--fail-only` command line argument.
 
 To run all tests against Chrome with experimental `moveBefore` support added, execute:
 ```bash

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "web-test-runner",
     "debug": "web-test-runner --manual --open",
     "test-move-before": "USE_MOVE_BEFORE=1 web-test-runner",
-    "ci": "web-test-runner --playwright --browsers chromium firefox webkit",
+    "ci": "web-test-runner --fail-only --playwright --browsers chromium firefox webkit",
     "amd": "(echo \"define(() => {\n\" && cat src/idiomorph.js && echo \"\nreturn Idiomorph});\") > dist/idiomorph.amd.js",
     "cjs": "(cat src/idiomorph.js && echo \"\nmodule.exports = Idiomorph;\") > dist/idiomorph.cjs.js",
     "esm": "(cat src/idiomorph.js && echo \"\nexport {Idiomorph};\") > dist/idiomorph.esm.js",

--- a/test/core.js
+++ b/test/core.js
@@ -320,7 +320,7 @@ describe("Core morphing tests", function(){
         document.body.removeChild(parent);
     });
 
-    it.only('can prevent element addition w/ the beforeNodeAdded callback', function() {
+    it('can prevent element addition w/ the beforeNodeAdded callback', function() {
         let parent = make("<div><p>1</p><p>2</p></div>");
         document.body.append(parent);
 

--- a/test/lib/fail-only.mjs
+++ b/test/lib/fail-only.mjs
@@ -1,0 +1,24 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export default {
+  name: 'fail-only',
+  async transform(context) {
+    const filePath = context.path;
+    const failOnlyEnabled = process.argv.includes('--fail-only');
+    if (failOnlyEnabled && filePath.match(/^\/test\/[^/]+\.js$/)) {
+      const fileContent = await fs.readFile(`.${filePath}`, 'utf-8');
+      if (/\bit\.only\b/.test(fileContent)) {
+        abort(`--fail-only:\nFound 'it.only' in ${filePath}. Remove it to proceed.`);
+      }
+    }
+  },
+};
+
+function abort(message) {
+  const RED = '\x1b[31m'; // Red color code
+  const RESET = '\x1b[0m'; // Reset color code
+  process.stderr.write(`${RED}${message}\n${RESET}`, () => {
+    process.exit(1);
+  });
+}

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -1,5 +1,6 @@
 import { chromeLauncher } from "@web/test-runner";
 import { exec } from "child_process";
+import failOnly from "./test/lib/fail-only.mjs";
 
 let config = {
   testRunnerHtml: (testFramework) => `
@@ -39,6 +40,7 @@ let config = {
     include: ['src/**/*'],
   },
   files: "test/*.js",
+  plugins: [failOnly],
 };
 
 if (process.env.USE_MOVE_BEFORE) {


### PR DESCRIPTION
I accidentally left an `it.only` in one of my recent commits, so CI was hamstrung without complaint. I think the presence of `it.only` should fail the CI build, to prevent this from happening again.

Two commits:
1. Create the `--fail-only` command line argument plugin, and enable it for `npm run ci`. I expect this to fail CI, because there's currently an `it.only` in `test/core.js`.
2. Remove the `it.only` and be green again.