### PR TITLE
Iterating over the NamedNodeMap returned by Element.prototype.attributes is unsafe and vulnerable to race conditions

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -439,6 +439,11 @@ var Idiomorph = (function () {
                 // iterate backwards to avoid skipping over items when a delete occurs
                 for (let i = toAttributes.length - 1; 0 <= i; i--) {
                     const toAttribute = toAttributes[i];
+
+                    // toAttributes is a live NamedNodeMap, so iteration+mutation is unsafe
+                    // e.g. custom element attribute callbacks can remove other attributes
+                    if (!toAttribute) continue;
+
                     if (!fromEl.hasAttribute(toAttribute.name)) {
                         if (ignoreAttribute(toAttribute.name, toEl, 'remove', ctx)) {
                             continue;

--- a/test/fidelity.js
+++ b/test/fidelity.js
@@ -110,5 +110,23 @@ describe("Tests to ensure that idiomorph merges properly", function(){
         should.equal(false, el1.disabled);
     });
 
+    it('issue https://github.com/bigskysoftware/idiomorph/issues/41', function()
+    {
+        window.customElements.define('fake-turbo-frame', class extends HTMLElement {
+            static observedAttributes = ['src'];
+            attributeChangedCallback(name, oldValue, newValue) {
+                if (name === 'src' && oldValue && oldValue !== newValue) {
+                    this.removeAttribute('complete');
+                }
+            }
+        });
+
+        let element = make('<fake-turbo-frame id="frame" complete="complete" src="https://example.com"></fake-turbo-frame>');
+        let finalSrc = '<fake-turbo-frame id="frame"></fake-turbo-frame>';
+
+        Idiomorph.morph(element, finalSrc);
+
+        element.outerHTML.should.equal(finalSrc);
+    });
 
 })


### PR DESCRIPTION
Closes #41 . More context there, but the gist of it is resolving this issue:

From https://www.oreilly.com/library/view/javascript-the-definitive/0596000480/re534.html (emphasis mine)
> Although the NamedNodeMap interface allows you to iterate through its nodes by position, it does not represent an ordered collection of nodes. Any changes made to the NamedNodeMap (such as by removeNamedItem( ) or setNamedItem( )) may result in a complete reordering of the elements. **Thus, you must not modify a NamedNodeMap while you are iterating through its elements.**