### PR TITLE
Add prettier to normalize code style

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+coverage/
+test/*/*
+!test/lib
+package.json
+package-lock.json
+tsconfig.json
+*.md
+.github
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "fs-extra": "^9.1.0",
         "htmx.org": "1.9.9",
         "p-wait-for": "^5.0.2",
+        "prettier": "^3.4.2",
         "sinon": "^9.2.4",
         "typescript": "^5.3.3",
         "uglify-js": "^3.15.0"
@@ -4950,6 +4951,21 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/progress": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "gen-modules": "npm run-script amd && npm run-script cjs && npm run-script esm",
     "dist": "cp -r src/* dist/ && cat src/idiomorph.js src/idiomorph-htmx.js > dist/idiomorph-ext.js && npm run-script gen-modules && npm run-script uglify && gzip -9 -k -f dist/idiomorph.min.js > dist/idiomorph.min.js.gz && exit",
     "uglify": "uglifyjs -m eval -o dist/idiomorph.min.js dist/idiomorph.js && uglifyjs -m eval -o dist/idiomorph-ext.min.js dist/idiomorph-ext.js",
+    "format": "prettier --write .",
+    "format-check": "prettier --check .",
     "typecheck": "tsc"
   },
   "repository": {
@@ -43,6 +45,7 @@
     "fs-extra": "^9.1.0",
     "htmx.org": "1.9.9",
     "p-wait-for": "^5.0.2",
+    "prettier": "^3.4.2",
     "sinon": "^9.2.4",
     "typescript": "^5.3.3",
     "uglify-js": "^3.15.0"

--- a/src/idiomorph-htmx.js
+++ b/src/idiomorph-htmx.js
@@ -1,24 +1,24 @@
-(function(){
-    function createMorphConfig(swapStyle) {
-        if (swapStyle === 'morph' || swapStyle === 'morph:outerHTML') {
-            return {morphStyle: 'outerHTML'}
-        } else if (swapStyle === 'morph:innerHTML') {
-            return {morphStyle: 'innerHTML'}
-        } else if (swapStyle.startsWith("morph:")) {
-            return Function("return (" + swapStyle.slice(6) + ")")();
-        }
+(function () {
+  function createMorphConfig(swapStyle) {
+    if (swapStyle === "morph" || swapStyle === "morph:outerHTML") {
+      return { morphStyle: "outerHTML" };
+    } else if (swapStyle === "morph:innerHTML") {
+      return { morphStyle: "innerHTML" };
+    } else if (swapStyle.startsWith("morph:")) {
+      return Function("return (" + swapStyle.slice(6) + ")")();
     }
+  }
 
-    htmx.defineExtension('morph', {
-        isInlineSwap: function(swapStyle) {
-            let config = createMorphConfig(swapStyle);
-            return config?.morphStyle === "outerHTML" || config?.morphStyle == null;
-        },
-        handleSwap: function (swapStyle, target, fragment) {
-            let config = createMorphConfig(swapStyle);
-            if (config) {
-                return Idiomorph.morph(target, fragment.children, config);
-            }
-        }
-    });
-})()
+  htmx.defineExtension("morph", {
+    isInlineSwap: function (swapStyle) {
+      let config = createMorphConfig(swapStyle);
+      return config?.morphStyle === "outerHTML" || config?.morphStyle == null;
+    },
+    handleSwap: function (swapStyle, target, fragment) {
+      let config = createMorphConfig(swapStyle);
+      if (config) {
+        return Idiomorph.morph(target, fragment.children, config);
+      }
+    },
+  });
+})();

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -90,1250 +90,1348 @@
  * @type {{defaults: ConfigInternal, morph: Morph}}
  */
 var Idiomorph = (function () {
-        'use strict';
+  "use strict";
 
-        /**
-         * @typedef {object} MorphContext
-         *
-         * @property {Node} target
-         * @property {Node} newContent
-         * @property {ConfigInternal} config
-         * @property {ConfigInternal['morphStyle']} morphStyle
-         * @property {ConfigInternal['ignoreActive']} ignoreActive
-         * @property {ConfigInternal['ignoreActiveValue']} ignoreActiveValue
-         * @property {Map<Node, Set<string>>} idMap
-         * @property {Set<string>} persistentIds
-         * @property {Set<string>} deadIds
-         * @property {ConfigInternal['callbacks']} callbacks
-         * @property {ConfigInternal['head']} head
-         * @property {HTMLDivElement} pantry
-         */
+  /**
+   * @typedef {object} MorphContext
+   *
+   * @property {Node} target
+   * @property {Node} newContent
+   * @property {ConfigInternal} config
+   * @property {ConfigInternal['morphStyle']} morphStyle
+   * @property {ConfigInternal['ignoreActive']} ignoreActive
+   * @property {ConfigInternal['ignoreActiveValue']} ignoreActiveValue
+   * @property {Map<Node, Set<string>>} idMap
+   * @property {Set<string>} persistentIds
+   * @property {Set<string>} deadIds
+   * @property {ConfigInternal['callbacks']} callbacks
+   * @property {ConfigInternal['head']} head
+   * @property {HTMLDivElement} pantry
+   */
 
-        //=============================================================================
-        // AND NOW IT BEGINS...
-        //=============================================================================
+  //=============================================================================
+  // AND NOW IT BEGINS...
+  //=============================================================================
 
-        /**
-         *
-         * @type {Set<string>}
-         */
-        let EMPTY_SET = new Set();
+  /**
+   *
+   * @type {Set<string>}
+   */
+  let EMPTY_SET = new Set();
 
-        /**
-         * Default configuration values, updatable by users now
-         * @type {ConfigInternal}
-         */
-        let defaults = {
-            morphStyle: "outerHTML",
-            callbacks : {
-                beforeNodeAdded: noOp,
-                afterNodeAdded: noOp,
-                beforeNodeMorphed: noOp,
-                afterNodeMorphed: noOp,
-                beforeNodeRemoved: noOp,
-                afterNodeRemoved: noOp,
-                beforeAttributeUpdated: noOp,
-                beforeNodePantried: noOp,
-            },
-            head: {
-                style: 'merge',
-                shouldPreserve: function (elt) {
-                    return elt.getAttribute("im-preserve") === "true";
-                },
-                shouldReAppend: function (elt) {
-                    return elt.getAttribute("im-re-append") === "true";
-                },
-                shouldRemove: noOp,
-                afterHeadMorphed: noOp,
-            }
-        };
+  /**
+   * Default configuration values, updatable by users now
+   * @type {ConfigInternal}
+   */
+  let defaults = {
+    morphStyle: "outerHTML",
+    callbacks: {
+      beforeNodeAdded: noOp,
+      afterNodeAdded: noOp,
+      beforeNodeMorphed: noOp,
+      afterNodeMorphed: noOp,
+      beforeNodeRemoved: noOp,
+      afterNodeRemoved: noOp,
+      beforeAttributeUpdated: noOp,
+      beforeNodePantried: noOp,
+    },
+    head: {
+      style: "merge",
+      shouldPreserve: function (elt) {
+        return elt.getAttribute("im-preserve") === "true";
+      },
+      shouldReAppend: function (elt) {
+        return elt.getAttribute("im-re-append") === "true";
+      },
+      shouldRemove: noOp,
+      afterHeadMorphed: noOp,
+    },
+  };
 
+  /**
+   * =============================================================================
+   * Core Morphing Algorithm - morph, morphNormalizedContent, morphOldNodeTo, morphChildren
+   * =============================================================================
+   *
+   * @param {Element | Document} oldNode
+   * @param {Element | Node | HTMLCollection | Node[] | string | null} newContent
+   * @param {Config} [config]
+   * @returns {undefined | Node[]}
+   */
+  function morph(oldNode, newContent, config = {}) {
+    if (oldNode instanceof Document) {
+      oldNode = oldNode.documentElement;
+    }
 
-        /**
-         * =============================================================================
-         * Core Morphing Algorithm - morph, morphNormalizedContent, morphOldNodeTo, morphChildren
-         * =============================================================================
-         *
-         * @param {Element | Document} oldNode
-         * @param {Element | Node | HTMLCollection | Node[] | string | null} newContent
-         * @param {Config} [config]
-         * @returns {undefined | Node[]}
-         */
-        function morph(oldNode, newContent, config = {}) {
+    if (typeof newContent === "string") {
+      newContent = parseContent(newContent);
+    }
 
-            if (oldNode instanceof Document) {
-                oldNode = oldNode.documentElement;
-            }
+    let normalizedContent = normalizeContent(newContent);
 
-            if (typeof newContent === 'string') {
-                newContent = parseContent(newContent);
-            }
+    let ctx = createMorphContext(oldNode, normalizedContent, config);
 
-            let normalizedContent = normalizeContent(newContent);
+    return morphNormalizedContent(oldNode, normalizedContent, ctx);
+  }
 
-            let ctx = createMorphContext(oldNode, normalizedContent, config);
+  /**
+   *
+   * @param {Element} oldNode
+   * @param {Element} normalizedNewContent
+   * @param {MorphContext} ctx
+   * @returns {undefined | Node[]}
+   */
+  function morphNormalizedContent(oldNode, normalizedNewContent, ctx) {
+    if (ctx.head.block) {
+      let oldHead = oldNode.querySelector("head");
+      let newHead = normalizedNewContent.querySelector("head");
+      if (oldHead && newHead) {
+        let promises = handleHeadElement(newHead, oldHead, ctx);
+        // when head promises resolve, call morph again, ignoring the head tag
+        Promise.all(promises).then(function () {
+          morphNormalizedContent(
+            oldNode,
+            normalizedNewContent,
+            Object.assign(ctx, {
+              head: {
+                block: false,
+                ignore: true,
+              },
+            }),
+          );
+        });
+        return;
+      }
+    }
 
-            return morphNormalizedContent(oldNode, normalizedContent, ctx);
+    if (ctx.morphStyle === "innerHTML") {
+      // innerHTML, so we are only updating the children
+      morphChildren(normalizedNewContent, oldNode, ctx);
+      if (ctx.config.twoPass) {
+        restoreFromPantry(oldNode, ctx);
+      }
+      return Array.from(oldNode.children);
+    } else if (ctx.morphStyle === "outerHTML" || ctx.morphStyle == null) {
+      // otherwise find the best element match in the new content, morph that, and merge its siblings
+      // into either side of the best match
+      let bestMatch = findBestNodeMatch(normalizedNewContent, oldNode, ctx);
+
+      // stash the siblings that will need to be inserted on either side of the best match
+      let previousSibling = bestMatch?.previousSibling ?? null;
+      let nextSibling = bestMatch?.nextSibling ?? null;
+
+      // morph it
+      let morphedNode = morphOldNodeTo(oldNode, bestMatch, ctx);
+
+      if (bestMatch) {
+        // if there was a best match, merge the siblings in too and return the
+        // whole bunch
+        if (morphedNode) {
+          const elements = insertSiblings(
+            previousSibling,
+            morphedNode,
+            nextSibling,
+          );
+          if (ctx.config.twoPass) {
+            restoreFromPantry(morphedNode.parentNode, ctx);
+          }
+          return elements;
+        }
+      } else {
+        // otherwise nothing was added to the DOM
+        return [];
+      }
+    } else {
+      throw "Do not understand how to morph style " + ctx.morphStyle;
+    }
+  }
+
+  /**
+   * @param {Node} possibleActiveElement
+   * @param {MorphContext} ctx
+   * @returns {boolean}
+   */
+  // TODO: ignoreActive and ignoreActiveValue are marked as optional since they are not
+  //   initialised in the default config object. As a result the && in the function body may
+  //   return undefined instead of boolean. Either expand the type of the return value to
+  //   include undefined or wrap the ctx.ignoreActiveValue into a Boolean()
+  function ignoreValueOfActiveElement(possibleActiveElement, ctx) {
+    return (
+      !!ctx.ignoreActiveValue &&
+      possibleActiveElement === document.activeElement &&
+      possibleActiveElement !== document.body
+    );
+  }
+
+  /**
+   * @param {Node} oldNode root node to merge content into
+   * @param {Node | null} newContent new content to merge
+   * @param {MorphContext} ctx the merge context
+   * @returns {Node | null} the element that ended up in the DOM
+   */
+  function morphOldNodeTo(oldNode, newContent, ctx) {
+    if (ctx.ignoreActive && oldNode === document.activeElement) {
+      // don't morph focused element
+    } else if (newContent == null) {
+      if (ctx.callbacks.beforeNodeRemoved(oldNode) === false) return oldNode;
+
+      oldNode.parentNode?.removeChild(oldNode);
+      ctx.callbacks.afterNodeRemoved(oldNode);
+      return null;
+    } else if (!isSoftMatch(oldNode, newContent)) {
+      if (ctx.callbacks.beforeNodeRemoved(oldNode) === false) return oldNode;
+      if (ctx.callbacks.beforeNodeAdded(newContent) === false) return oldNode;
+
+      oldNode.parentNode?.replaceChild(newContent, oldNode);
+      ctx.callbacks.afterNodeAdded(newContent);
+      ctx.callbacks.afterNodeRemoved(oldNode);
+      return newContent;
+    } else {
+      if (ctx.callbacks.beforeNodeMorphed(oldNode, newContent) === false)
+        return oldNode;
+
+      if (oldNode instanceof HTMLHeadElement && ctx.head.ignore) {
+        // ignore the head element
+      } else if (
+        oldNode instanceof HTMLHeadElement &&
+        ctx.head.style !== "morph"
+      ) {
+        // ok to cast: if newContent wasn't also a <head>, it would've got caught in the `!isSoftMatch` branch above
+        handleHeadElement(
+          /** @type {HTMLHeadElement} */ (newContent),
+          oldNode,
+          ctx,
+        );
+      } else {
+        syncNodeFrom(newContent, oldNode, ctx);
+        if (!ignoreValueOfActiveElement(oldNode, ctx)) {
+          morphChildren(newContent, oldNode, ctx);
+        }
+      }
+      ctx.callbacks.afterNodeMorphed(oldNode, newContent);
+      return oldNode;
+    }
+    return null;
+  }
+
+  /**
+   * This is the core algorithm for matching up children.  The idea is to use id sets to try to match up
+   * nodes as faithfully as possible.  We greedily match, which allows us to keep the algorithm fast, but
+   * by using id sets, we are able to better match up with content deeper in the DOM.
+   *
+   * Basic algorithm is, for each node in the new content:
+   *
+   * - if we have reached the end of the old parent, append the new content
+   * - if the new content has an id set match with the current insertion point, morph
+   * - search for an id set match
+   * - if id set match found, morph
+   * - otherwise search for a "soft" match
+   * - if a soft match is found, morph
+   * - otherwise, prepend the new node before the current insertion point
+   *
+   * The two search algorithms terminate if competing node matches appear to outweigh what can be achieved
+   * with the current node.  See findIdSetMatch() and findSoftMatch() for details.
+   *
+   * @param {Node} newParent the parent element of the new content
+   * @param {Node} oldParent the old content that we are merging the new content into
+   * @param {MorphContext} ctx the merge context
+   * @returns {void}
+   */
+  function morphChildren(newParent, oldParent, ctx) {
+    if (
+      newParent instanceof HTMLTemplateElement &&
+      oldParent instanceof HTMLTemplateElement
+    ) {
+      newParent = newParent.content;
+      oldParent = oldParent.content;
+    }
+
+    /**
+     *
+     * @type {Node | null}
+     */
+    let nextNewChild = newParent.firstChild;
+    /**
+     *
+     * @type {Node | null}
+     */
+    let insertionPoint = oldParent.firstChild;
+    let newChild;
+
+    // run through all the new content
+    while (nextNewChild) {
+      newChild = nextNewChild;
+      nextNewChild = newChild.nextSibling;
+
+      // if we are at the end of the exiting parent's children, just append
+      if (insertionPoint == null) {
+        // skip add callbacks when we're going to be restoring this from the pantry in the second pass
+        if (
+          ctx.config.twoPass &&
+          ctx.persistentIds.has(/** @type {Element} */ (newChild).id)
+        ) {
+          oldParent.appendChild(newChild);
+        } else {
+          if (ctx.callbacks.beforeNodeAdded(newChild) === false) continue;
+          oldParent.appendChild(newChild);
+          ctx.callbacks.afterNodeAdded(newChild);
+        }
+        removeIdsFromConsideration(ctx, newChild);
+        continue;
+      }
+
+      // if the current node has an id set match then morph
+      if (isIdSetMatch(newChild, insertionPoint, ctx)) {
+        morphOldNodeTo(insertionPoint, newChild, ctx);
+        insertionPoint = insertionPoint.nextSibling;
+        removeIdsFromConsideration(ctx, newChild);
+        continue;
+      }
+
+      // otherwise search forward in the existing old children for an id set match
+      let idSetMatch = findIdSetMatch(
+        newParent,
+        oldParent,
+        newChild,
+        insertionPoint,
+        ctx,
+      );
+
+      // if we found a potential match, remove the nodes until that point and morph
+      if (idSetMatch) {
+        insertionPoint = removeNodesBetween(insertionPoint, idSetMatch, ctx);
+        morphOldNodeTo(idSetMatch, newChild, ctx);
+        removeIdsFromConsideration(ctx, newChild);
+        continue;
+      }
+
+      // no id set match found, so scan forward for a soft match for the current node
+      let softMatch = findSoftMatch(
+        newParent,
+        oldParent,
+        newChild,
+        insertionPoint,
+        ctx,
+      );
+
+      // if we found a soft match for the current node, morph
+      if (softMatch) {
+        insertionPoint = removeNodesBetween(insertionPoint, softMatch, ctx);
+        morphOldNodeTo(softMatch, newChild, ctx);
+        removeIdsFromConsideration(ctx, newChild);
+        continue;
+      }
+
+      // abandon all hope of morphing, just insert the new child before the insertion point
+      // and move on
+
+      // skip add callbacks when we're going to be restoring this from the pantry in the second pass
+      if (
+        ctx.config.twoPass &&
+        ctx.persistentIds.has(/** @type {Element} */ (newChild).id)
+      ) {
+        oldParent.insertBefore(newChild, insertionPoint);
+      } else {
+        if (ctx.callbacks.beforeNodeAdded(newChild) === false) continue;
+        oldParent.insertBefore(newChild, insertionPoint);
+        ctx.callbacks.afterNodeAdded(newChild);
+      }
+      removeIdsFromConsideration(ctx, newChild);
+    }
+
+    // remove any remaining old nodes that didn't match up with new content
+    while (insertionPoint !== null) {
+      let tempNode = insertionPoint;
+      insertionPoint = insertionPoint.nextSibling;
+      removeNode(tempNode, ctx);
+    }
+  }
+
+  //=============================================================================
+  // Attribute Syncing Code
+  //=============================================================================
+
+  /**
+   * @param {string} attr the attribute to be mutated
+   * @param {Element} to the element that is going to be updated
+   * @param {"update" | "remove"} updateType
+   * @param {MorphContext} ctx the merge context
+   * @returns {boolean} true if the attribute should be ignored, false otherwise
+   */
+  function ignoreAttribute(attr, to, updateType, ctx) {
+    if (
+      attr === "value" &&
+      ctx.ignoreActiveValue &&
+      to === document.activeElement
+    ) {
+      return true;
+    }
+    return ctx.callbacks.beforeAttributeUpdated(attr, to, updateType) === false;
+  }
+
+  /**
+   * syncs a given node with another node, copying over all attributes and
+   * inner element state from the 'from' node to the 'to' node
+   *
+   * @param {Node} from the element to copy attributes & state from
+   * @param {Node} to the element to copy attributes & state to
+   * @param {MorphContext} ctx the merge context
+   */
+  function syncNodeFrom(from, to, ctx) {
+    let type = from.nodeType;
+
+    // if is an element type, sync the attributes from the
+    // new node into the new node
+    if (type === 1 /* element type */) {
+      const fromEl = /** @type {Element} */ (from);
+      const toEl = /** @type {Element} */ (to);
+      const fromAttributes = fromEl.attributes;
+      const toAttributes = toEl.attributes;
+      for (const fromAttribute of fromAttributes) {
+        if (ignoreAttribute(fromAttribute.name, toEl, "update", ctx)) {
+          continue;
+        }
+        if (toEl.getAttribute(fromAttribute.name) !== fromAttribute.value) {
+          toEl.setAttribute(fromAttribute.name, fromAttribute.value);
+        }
+      }
+      // iterate backwards to avoid skipping over items when a delete occurs
+      for (let i = toAttributes.length - 1; 0 <= i; i--) {
+        const toAttribute = toAttributes[i];
+
+        // toAttributes is a live NamedNodeMap, so iteration+mutation is unsafe
+        // e.g. custom element attribute callbacks can remove other attributes
+        if (!toAttribute) continue;
+
+        if (!fromEl.hasAttribute(toAttribute.name)) {
+          if (ignoreAttribute(toAttribute.name, toEl, "remove", ctx)) {
+            continue;
+          }
+          toEl.removeAttribute(toAttribute.name);
+        }
+      }
+    }
+
+    // sync text nodes
+    if (type === 8 /* comment */ || type === 3 /* text */) {
+      if (to.nodeValue !== from.nodeValue) {
+        to.nodeValue = from.nodeValue;
+      }
+    }
+
+    if (!ignoreValueOfActiveElement(to, ctx)) {
+      // sync input values
+      syncInputValue(from, to, ctx);
+    }
+  }
+
+  /**
+   * @param {Element} from element to sync the value from
+   * @param {Element} to element to sync the value to
+   * @param {string} attributeName the attribute name
+   * @param {MorphContext} ctx the merge context
+   */
+  function syncBooleanAttribute(from, to, attributeName, ctx) {
+    // TODO: prefer set/getAttribute here
+    if (!(from instanceof Element && to instanceof Element)) return;
+    // @ts-ignore this function is only used on boolean attrs that are reflected as dom properties
+    const fromLiveValue = from[attributeName],
+      toLiveValue = to[attributeName];
+    if (fromLiveValue !== toLiveValue) {
+      let ignoreUpdate = ignoreAttribute(attributeName, to, "update", ctx);
+      if (!ignoreUpdate) {
+        // update attribute's associated DOM property
+        // @ts-ignore this function is only used on boolean attrs that are reflected as dom properties
+        to[attributeName] = from[attributeName];
+      }
+      if (fromLiveValue) {
+        if (!ignoreUpdate) {
+          // TODO: do we really want this? tests say so but it feels wrong
+          to.setAttribute(attributeName, fromLiveValue);
+        }
+      } else {
+        if (!ignoreAttribute(attributeName, to, "remove", ctx)) {
+          to.removeAttribute(attributeName);
+        }
+      }
+    }
+  }
+
+  /**
+   * NB: many bothans died to bring us information:
+   *
+   *  https://github.com/patrick-steele-idem/morphdom/blob/master/src/specialElHandlers.js
+   *  https://github.com/choojs/nanomorph/blob/master/lib/morph.jsL113
+   *
+   * @param {Node} from the element to sync the input value from
+   * @param {Node} to the element to sync the input value to
+   * @param {MorphContext} ctx the merge context
+   */
+  function syncInputValue(from, to, ctx) {
+    if (
+      from instanceof HTMLInputElement &&
+      to instanceof HTMLInputElement &&
+      from.type !== "file"
+    ) {
+      let fromValue = from.value;
+      let toValue = to.value;
+
+      // sync boolean attributes
+      syncBooleanAttribute(from, to, "checked", ctx);
+      syncBooleanAttribute(from, to, "disabled", ctx);
+
+      if (!from.hasAttribute("value")) {
+        if (!ignoreAttribute("value", to, "remove", ctx)) {
+          to.value = "";
+          to.removeAttribute("value");
+        }
+      } else if (fromValue !== toValue) {
+        if (!ignoreAttribute("value", to, "update", ctx)) {
+          to.setAttribute("value", fromValue);
+          to.value = fromValue;
+        }
+      }
+      // TODO: QUESTION(1cg): this used to only check `from` unlike the other branches -- why?
+      // did I break something?
+    } else if (
+      from instanceof HTMLOptionElement &&
+      to instanceof HTMLOptionElement
+    ) {
+      syncBooleanAttribute(from, to, "selected", ctx);
+    } else if (
+      from instanceof HTMLTextAreaElement &&
+      to instanceof HTMLTextAreaElement
+    ) {
+      let fromValue = from.value;
+      let toValue = to.value;
+      if (ignoreAttribute("value", to, "update", ctx)) {
+        return;
+      }
+      if (fromValue !== toValue) {
+        to.value = fromValue;
+      }
+      if (to.firstChild && to.firstChild.nodeValue !== fromValue) {
+        to.firstChild.nodeValue = fromValue;
+      }
+    }
+  }
+
+  /**
+   * =============================================================================
+   *  The HEAD tag can be handled specially, either w/ a 'merge' or 'append' style
+   * =============================================================================
+   * @param {Element} newHeadTag
+   * @param {Element} currentHead
+   * @param {MorphContext} ctx
+   * @returns {Promise<void>[]}
+   */
+  function handleHeadElement(newHeadTag, currentHead, ctx) {
+    /**
+     * @type {Node[]}
+     */
+    let added = [];
+    /**
+     * @type {Element[]}
+     */
+    let removed = [];
+    /**
+     * @type {Element[]}
+     */
+    let preserved = [];
+    /**
+     * @type {Element[]}
+     */
+    let nodesToAppend = [];
+
+    let headMergeStyle = ctx.head.style;
+
+    // put all new head elements into a Map, by their outerHTML
+    let srcToNewHeadNodes = new Map();
+    for (const newHeadChild of newHeadTag.children) {
+      srcToNewHeadNodes.set(newHeadChild.outerHTML, newHeadChild);
+    }
+
+    // for each elt in the current head
+    for (const currentHeadElt of currentHead.children) {
+      // If the current head element is in the map
+      let inNewContent = srcToNewHeadNodes.has(currentHeadElt.outerHTML);
+      let isReAppended = ctx.head.shouldReAppend(currentHeadElt);
+      let isPreserved = ctx.head.shouldPreserve(currentHeadElt);
+      if (inNewContent || isPreserved) {
+        if (isReAppended) {
+          // remove the current version and let the new version replace it and re-execute
+          removed.push(currentHeadElt);
+        } else {
+          // this element already exists and should not be re-appended, so remove it from
+          // the new content map, preserving it in the DOM
+          srcToNewHeadNodes.delete(currentHeadElt.outerHTML);
+          preserved.push(currentHeadElt);
+        }
+      } else {
+        if (headMergeStyle === "append") {
+          // we are appending and this existing element is not new content
+          // so if and only if it is marked for re-append do we do anything
+          if (isReAppended) {
+            removed.push(currentHeadElt);
+            nodesToAppend.push(currentHeadElt);
+          }
+        } else {
+          // if this is a merge, we remove this content since it is not in the new head
+          if (ctx.head.shouldRemove(currentHeadElt) !== false) {
+            removed.push(currentHeadElt);
+          }
+        }
+      }
+    }
+
+    // Push the remaining new head elements in the Map into the
+    // nodes to append to the head tag
+    nodesToAppend.push(...srcToNewHeadNodes.values());
+    log("to append: ", nodesToAppend);
+
+    let promises = [];
+    for (const newNode of nodesToAppend) {
+      log("adding: ", newNode);
+      // TODO: This could theoretically be null, based on type
+      let newElt = /** @type {ChildNode} */ (
+        document.createRange().createContextualFragment(newNode.outerHTML)
+          .firstChild
+      );
+      log(newElt);
+      if (ctx.callbacks.beforeNodeAdded(newElt) !== false) {
+        if (
+          ("href" in newElt && newElt.href) ||
+          ("src" in newElt && newElt.src)
+        ) {
+          /** @type {(result?: any) => void} */ let resolve;
+          let promise = new Promise(function (_resolve) {
+            resolve = _resolve;
+          });
+          newElt.addEventListener("load", function () {
+            resolve();
+          });
+          promises.push(promise);
+        }
+        currentHead.appendChild(newElt);
+        ctx.callbacks.afterNodeAdded(newElt);
+        added.push(newElt);
+      }
+    }
+
+    // remove all removed elements, after we have appended the new elements to avoid
+    // additional network requests for things like style sheets
+    for (const removedElement of removed) {
+      if (ctx.callbacks.beforeNodeRemoved(removedElement) !== false) {
+        currentHead.removeChild(removedElement);
+        ctx.callbacks.afterNodeRemoved(removedElement);
+      }
+    }
+
+    ctx.head.afterHeadMorphed(currentHead, {
+      added: added,
+      kept: preserved,
+      removed: removed,
+    });
+    return promises;
+  }
+
+  //=============================================================================
+  // Misc
+  //=============================================================================
+
+  /**
+   * @param {any[]} _args
+   */
+  function log(..._args) {
+    //console.log(args);
+  }
+
+  function noOp() {}
+
+  /**
+   * Deep merges the config object and the Idiomoroph.defaults object to
+   * produce a final configuration object
+   * @param {Config} config
+   * @returns {ConfigInternal}
+   */
+  function mergeDefaults(config) {
+    /**
+     * @type {ConfigInternal}
+     */
+    let finalConfig = Object.assign({}, defaults);
+
+    // copy top level stuff into final config
+    Object.assign(finalConfig, config);
+
+    // copy callbacks into final config (do this to deep merge the callbacks)
+    finalConfig.callbacks = Object.assign(
+      {},
+      defaults.callbacks,
+      config.callbacks,
+    );
+
+    // copy head config into final config  (do this to deep merge the head)
+    finalConfig.head = Object.assign({}, defaults.head, config.head);
+
+    return finalConfig;
+  }
+
+  /**
+   *
+   * @param {Element} oldNode
+   * @param {Element} newContent
+   * @param {Config} config
+   * @returns {MorphContext}
+   */
+  function createMorphContext(oldNode, newContent, config) {
+    const mergedConfig = mergeDefaults(config);
+    return {
+      target: oldNode,
+      newContent: newContent,
+      config: mergedConfig,
+      morphStyle: mergedConfig.morphStyle,
+      ignoreActive: mergedConfig.ignoreActive,
+      ignoreActiveValue: mergedConfig.ignoreActiveValue,
+      idMap: createIdMap(oldNode, newContent),
+      deadIds: new Set(),
+      persistentIds: mergedConfig.twoPass
+        ? createPersistentIds(oldNode, newContent)
+        : new Set(),
+      pantry: mergedConfig.twoPass
+        ? createPantry()
+        : document.createElement("div"),
+      callbacks: mergedConfig.callbacks,
+      head: mergedConfig.head,
+    };
+  }
+
+  function createPantry() {
+    const pantry = document.createElement("div");
+    pantry.hidden = true;
+    document.body.insertAdjacentElement("afterend", pantry);
+    return pantry;
+  }
+
+  /**
+   *
+   * @param {Node | null} node1
+   * @param {Node | null} node2
+   * @param {MorphContext} ctx
+   * @returns {boolean}
+   */
+  // TODO: The function handles this as if it's Element or null, but the function is called in
+  //   places where the arguments may be just a Node, not an Element
+  function isIdSetMatch(node1, node2, ctx) {
+    if (node1 == null || node2 == null) {
+      return false;
+    }
+    if (
+      node1 instanceof Element &&
+      node2 instanceof Element &&
+      node1.tagName === node2.tagName
+    ) {
+      if (node1.id !== "" && node1.id === node2.id) {
+        return true;
+      } else {
+        return getIdIntersectionCount(ctx, node1, node2) > 0;
+      }
+    }
+    return false;
+  }
+
+  /**
+   *
+   * @param {Node | null} oldNode
+   * @param {Node | null} newNode
+   * @returns {boolean}
+   */
+  function isSoftMatch(oldNode, newNode) {
+    if (oldNode == null || newNode == null) {
+      return false;
+    }
+    // ok to cast: if one is not element, `id` or `tagName` will be undefined and we'll compare that
+    // If oldNode has an `id` with possible state and it doesn't match newNode.id then avoid morphing
+    if (
+      /** @type {Element} */ (oldNode).id &&
+      /** @type {Element} */ (oldNode).id !==
+        /** @type {Element} */ (newNode).id
+    ) {
+      return false;
+    }
+    return (
+      oldNode.nodeType === newNode.nodeType &&
+      /** @type {Element} */ (oldNode).tagName ===
+        /** @type {Element} */ (newNode).tagName
+    );
+  }
+
+  /**
+   *
+   * @param {Node} startInclusive
+   * @param {Node} endExclusive
+   * @param {MorphContext} ctx
+   * @returns {Node | null}
+   */
+  function removeNodesBetween(startInclusive, endExclusive, ctx) {
+    /** @type {Node | null} */ let cursor = startInclusive;
+    while (cursor !== endExclusive) {
+      let tempNode = /** @type {Node} */ (cursor);
+      // TODO: Prefer assigning to a new variable here or expand the type of startInclusive
+      //  to be Node | null
+      cursor = tempNode.nextSibling;
+      removeNode(tempNode, ctx);
+    }
+    removeIdsFromConsideration(ctx, endExclusive);
+    return endExclusive.nextSibling;
+  }
+
+  /**
+   * =============================================================================
+   *  Scans forward from the insertionPoint in the old parent looking for a potential id match
+   *  for the newChild.  We stop if we find a potential id match for the new child OR
+   *  if the number of potential id matches we are discarding is greater than the
+   *  potential id matches for the new child
+   * =============================================================================
+   * @param {Node} newContent
+   * @param {Node} oldParent
+   * @param {Node} newChild
+   * @param {Node} insertionPoint
+   * @param {MorphContext} ctx
+   * @returns {null | Node}
+   */
+  function findIdSetMatch(
+    newContent,
+    oldParent,
+    newChild,
+    insertionPoint,
+    ctx,
+  ) {
+    // max id matches we are willing to discard in our search
+    let newChildPotentialIdCount = getIdIntersectionCount(
+      ctx,
+      newChild,
+      oldParent,
+    );
+
+    /**
+     * @type {Node | null}
+     */
+    let potentialMatch = null;
+
+    // only search forward if there is a possibility of an id match
+    if (newChildPotentialIdCount > 0) {
+      // TODO: This is ghosting the potentialMatch variable outside of this block.
+      //   Probably an error
+      potentialMatch = insertionPoint;
+      // if there is a possibility of an id match, scan forward
+      // keep track of the potential id match count we are discarding (the
+      // newChildPotentialIdCount must be greater than this to make it likely
+      // worth it)
+      let otherMatchCount = 0;
+      while (potentialMatch != null) {
+        // If we have an id match, return the current potential match
+        if (isIdSetMatch(newChild, potentialMatch, ctx)) {
+          return potentialMatch;
         }
 
-        /**
-         *
-         * @param {Element} oldNode
-         * @param {Element} normalizedNewContent
-         * @param {MorphContext} ctx
-         * @returns {undefined | Node[]}
-         */
-        function morphNormalizedContent(oldNode, normalizedNewContent, ctx) {
-            if (ctx.head.block) {
-                let oldHead = oldNode.querySelector('head');
-                let newHead = normalizedNewContent.querySelector('head');
-                if (oldHead && newHead) {
-                    let promises = handleHeadElement(newHead, oldHead, ctx);
-                    // when head promises resolve, call morph again, ignoring the head tag
-                    Promise.all(promises).then(function () {
-                        morphNormalizedContent(oldNode, normalizedNewContent, Object.assign(ctx, {
-                            head: {
-                                block: false,
-                                ignore: true
-                            }
-                        }));
-                    });
-                    return;
-                }
-            }
-
-            if (ctx.morphStyle === "innerHTML") {
-
-                // innerHTML, so we are only updating the children
-                morphChildren(normalizedNewContent, oldNode, ctx);
-                if (ctx.config.twoPass) {
-                    restoreFromPantry(oldNode, ctx);
-                }
-                return Array.from(oldNode.children);
-
-            } else if (ctx.morphStyle === "outerHTML" || ctx.morphStyle == null) {
-                // otherwise find the best element match in the new content, morph that, and merge its siblings
-                // into either side of the best match
-                let bestMatch = findBestNodeMatch(normalizedNewContent, oldNode, ctx);
-
-                // stash the siblings that will need to be inserted on either side of the best match
-                let previousSibling = bestMatch?.previousSibling ?? null;
-                let nextSibling = bestMatch?.nextSibling ?? null;
-
-                // morph it
-                let morphedNode = morphOldNodeTo(oldNode, bestMatch, ctx);
-
-                if (bestMatch) {
-                    // if there was a best match, merge the siblings in too and return the
-                    // whole bunch
-                    if (morphedNode) {
-                        const elements = insertSiblings(previousSibling, morphedNode, nextSibling);
-                        if (ctx.config.twoPass) {
-                            restoreFromPantry(morphedNode.parentNode, ctx);
-                        }
-                        return elements
-                    }
-                } else {
-                    // otherwise nothing was added to the DOM
-                    return []
-                }
-            } else {
-                throw "Do not understand how to morph style " + ctx.morphStyle;
-            }
+        // computer the other potential matches of this new content
+        otherMatchCount += getIdIntersectionCount(
+          ctx,
+          potentialMatch,
+          newContent,
+        );
+        if (otherMatchCount > newChildPotentialIdCount) {
+          // if we have more potential id matches in _other_ content, we
+          // do not have a good candidate for an id match, so return null
+          return null;
         }
 
+        // advanced to the next old content child
+        potentialMatch = potentialMatch.nextSibling;
+      }
+    }
+    return potentialMatch;
+  }
 
-        /**
-         * @param {Node} possibleActiveElement
-         * @param {MorphContext} ctx
-         * @returns {boolean}
-         */
-        // TODO: ignoreActive and ignoreActiveValue are marked as optional since they are not
-        //   initialised in the default config object. As a result the && in the function body may
-        //   return undefined instead of boolean. Either expand the type of the return value to
-        //   include undefined or wrap the ctx.ignoreActiveValue into a Boolean()
-        function ignoreValueOfActiveElement(possibleActiveElement, ctx) {
-            return !!ctx.ignoreActiveValue && possibleActiveElement === document.activeElement && possibleActiveElement !== document.body;
+  /**
+   * =============================================================================
+   *  Scans forward from the insertionPoint in the old parent looking for a potential soft match
+   *  for the newChild.  We stop if we find a potential soft match for the new child OR
+   *  if we find a potential id match in the old parents children OR if we find two
+   *  potential soft matches for the next two pieces of new content
+   * =============================================================================
+   * @param {Node} newContent
+   * @param {Node} oldParent
+   * @param {Node} newChild
+   * @param {Node} insertionPoint
+   * @param {MorphContext} ctx
+   * @returns {null | Node}
+   */
+  function findSoftMatch(newContent, oldParent, newChild, insertionPoint, ctx) {
+    /**
+     * @type {Node | null}
+     */
+    let potentialSoftMatch = insertionPoint;
+    /**
+     * @type {Node | null}
+     */
+    let nextSibling = newChild.nextSibling;
+    let siblingSoftMatchCount = 0;
+
+    while (potentialSoftMatch != null) {
+      if (getIdIntersectionCount(ctx, potentialSoftMatch, newContent) > 0) {
+        // the current potential soft match has a potential id set match with the remaining new
+        // content so bail out of looking
+        return null;
+      }
+
+      // if we have a soft match with the current node, return it
+      if (isSoftMatch(potentialSoftMatch, newChild)) {
+        return potentialSoftMatch;
+      }
+
+      if (isSoftMatch(potentialSoftMatch, nextSibling)) {
+        // the next new node has a soft match with this node, so
+        // increment the count of future soft matches
+        siblingSoftMatchCount++;
+        // ok to cast: if it was null it couldn't be a soft match
+        nextSibling = /** @type {Node} */ (nextSibling).nextSibling;
+
+        // If there are two future soft matches, bail to allow the siblings to soft match
+        // so that we don't consume future soft matches for the sake of the current node
+        if (siblingSoftMatchCount >= 2) {
+          return null;
         }
+      }
 
-        /**
-         * @param {Node} oldNode root node to merge content into
-         * @param {Node | null} newContent new content to merge
-         * @param {MorphContext} ctx the merge context
-         * @returns {Node | null} the element that ended up in the DOM
-         */
-        function morphOldNodeTo(oldNode, newContent, ctx) {
-            if (ctx.ignoreActive && oldNode === document.activeElement) {
-                // don't morph focused element
-            } else if (newContent == null) {
-                if (ctx.callbacks.beforeNodeRemoved(oldNode) === false) return oldNode;
+      // advanced to the next old content child
+      potentialSoftMatch = potentialSoftMatch.nextSibling;
+    }
 
-                oldNode.parentNode?.removeChild(oldNode);
-                ctx.callbacks.afterNodeRemoved(oldNode);
-                return null;
-            } else if (!isSoftMatch(oldNode, newContent)) {
-                if (ctx.callbacks.beforeNodeRemoved(oldNode) === false) return oldNode;
-                if (ctx.callbacks.beforeNodeAdded(newContent) === false) return oldNode;
+    return potentialSoftMatch;
+  }
 
-                oldNode.parentNode?.replaceChild(newContent, oldNode);
-                ctx.callbacks.afterNodeAdded(newContent);
-                ctx.callbacks.afterNodeRemoved(oldNode);
-                return newContent;
-            } else {
-                if (ctx.callbacks.beforeNodeMorphed(oldNode, newContent) === false) return oldNode;
+  /** @type {WeakSet<Node>} */
+  const generatedByIdiomorph = new WeakSet();
 
-                if (oldNode instanceof HTMLHeadElement && ctx.head.ignore) {
-                    // ignore the head element
-                } else if (oldNode instanceof HTMLHeadElement && ctx.head.style !== "morph") {
-                    // ok to cast: if newContent wasn't also a <head>, it would've got caught in the `!isSoftMatch` branch above
-                    handleHeadElement(/** @type {HTMLHeadElement} */ (newContent), oldNode, ctx);
-                } else {
-                    syncNodeFrom(newContent, oldNode, ctx);
-                    if (!ignoreValueOfActiveElement(oldNode, ctx)) {
-                        morphChildren(newContent, oldNode, ctx);
-                    }
-                }
-                ctx.callbacks.afterNodeMorphed(oldNode, newContent);
-                return oldNode;
-            }
-            return null;
+  /**
+   *
+   * @param {string} newContent
+   * @returns {Node | null | DocumentFragment}
+   */
+  function parseContent(newContent) {
+    let parser = new DOMParser();
+
+    // remove svgs to avoid false-positive matches on head, etc.
+    let contentWithSvgsRemoved = newContent.replace(
+      /<svg(\s[^>]*>|>)([\s\S]*?)<\/svg>/gim,
+      "",
+    );
+
+    // if the newContent contains a html, head or body tag, we can simply parse it w/o wrapping
+    if (
+      contentWithSvgsRemoved.match(/<\/html>/) ||
+      contentWithSvgsRemoved.match(/<\/head>/) ||
+      contentWithSvgsRemoved.match(/<\/body>/)
+    ) {
+      let content = parser.parseFromString(newContent, "text/html");
+      // if it is a full HTML document, return the document itself as the parent container
+      if (contentWithSvgsRemoved.match(/<\/html>/)) {
+        generatedByIdiomorph.add(content);
+        return content;
+      } else {
+        // otherwise return the html element as the parent container
+        let htmlElement = content.firstChild;
+        if (htmlElement) {
+          generatedByIdiomorph.add(htmlElement);
+          return htmlElement;
+        } else {
+          return null;
         }
-
-        /**
-         * This is the core algorithm for matching up children.  The idea is to use id sets to try to match up
-         * nodes as faithfully as possible.  We greedily match, which allows us to keep the algorithm fast, but
-         * by using id sets, we are able to better match up with content deeper in the DOM.
-         *
-         * Basic algorithm is, for each node in the new content:
-         *
-         * - if we have reached the end of the old parent, append the new content
-         * - if the new content has an id set match with the current insertion point, morph
-         * - search for an id set match
-         * - if id set match found, morph
-         * - otherwise search for a "soft" match
-         * - if a soft match is found, morph
-         * - otherwise, prepend the new node before the current insertion point
-         *
-         * The two search algorithms terminate if competing node matches appear to outweigh what can be achieved
-         * with the current node.  See findIdSetMatch() and findSoftMatch() for details.
-         *
-         * @param {Node} newParent the parent element of the new content
-         * @param {Node} oldParent the old content that we are merging the new content into
-         * @param {MorphContext} ctx the merge context
-         * @returns {void}
-         */
-        function morphChildren(newParent, oldParent, ctx) {
-            if (newParent instanceof HTMLTemplateElement && oldParent instanceof HTMLTemplateElement) {
-              newParent = newParent.content;
-              oldParent = oldParent.content;
-            }
-
-            /**
-             *
-             * @type {Node | null}
-             */
-            let nextNewChild = newParent.firstChild;
-            /**
-             *
-             * @type {Node | null}
-             */
-            let insertionPoint = oldParent.firstChild;
-            let newChild;
-
-            // run through all the new content
-            while (nextNewChild) {
-
-                newChild = nextNewChild;
-                nextNewChild = newChild.nextSibling;
-
-                // if we are at the end of the exiting parent's children, just append
-                if (insertionPoint == null) {
-                    // skip add callbacks when we're going to be restoring this from the pantry in the second pass
-                    if (ctx.config.twoPass && ctx.persistentIds.has(/** @type {Element} */ (newChild).id)) {
-                        oldParent.appendChild(newChild);
-                    } else {
-                        if (ctx.callbacks.beforeNodeAdded(newChild) === false) continue;
-                        oldParent.appendChild(newChild);
-                        ctx.callbacks.afterNodeAdded(newChild);
-                    }
-                    removeIdsFromConsideration(ctx, newChild);
-                    continue;
-                }
-
-                // if the current node has an id set match then morph
-                if (isIdSetMatch(newChild, insertionPoint, ctx)) {
-                    morphOldNodeTo(insertionPoint, newChild, ctx);
-                    insertionPoint = insertionPoint.nextSibling;
-                    removeIdsFromConsideration(ctx, newChild);
-                    continue;
-                }
-
-                // otherwise search forward in the existing old children for an id set match
-                let idSetMatch = findIdSetMatch(newParent, oldParent, newChild, insertionPoint, ctx);
-
-                // if we found a potential match, remove the nodes until that point and morph
-                if (idSetMatch) {
-                    insertionPoint = removeNodesBetween(insertionPoint, idSetMatch, ctx);
-                    morphOldNodeTo(idSetMatch, newChild, ctx);
-                    removeIdsFromConsideration(ctx, newChild);
-                    continue;
-                }
-
-                // no id set match found, so scan forward for a soft match for the current node
-                let softMatch = findSoftMatch(newParent, oldParent, newChild, insertionPoint, ctx);
-
-                // if we found a soft match for the current node, morph
-                if (softMatch) {
-                    insertionPoint = removeNodesBetween(insertionPoint, softMatch, ctx);
-                    morphOldNodeTo(softMatch, newChild, ctx);
-                    removeIdsFromConsideration(ctx, newChild);
-                    continue;
-                }
-
-                // abandon all hope of morphing, just insert the new child before the insertion point
-                // and move on
-
-                // skip add callbacks when we're going to be restoring this from the pantry in the second pass
-                if (ctx.config.twoPass && ctx.persistentIds.has(/** @type {Element} */ (newChild).id)) {
-                    oldParent.insertBefore(newChild, insertionPoint);
-                } else {
-                    if (ctx.callbacks.beforeNodeAdded(newChild) === false) continue;
-                    oldParent.insertBefore(newChild, insertionPoint);
-                    ctx.callbacks.afterNodeAdded(newChild);
-                }
-                removeIdsFromConsideration(ctx, newChild);
-            }
-
-            // remove any remaining old nodes that didn't match up with new content
-            while (insertionPoint !== null) {
-
-                let tempNode = insertionPoint;
-                insertionPoint = insertionPoint.nextSibling;
-                removeNode(tempNode, ctx);
-            }
-        }
-
-        //=============================================================================
-        // Attribute Syncing Code
-        //=============================================================================
-
-        /**
-         * @param {string} attr the attribute to be mutated
-         * @param {Element} to the element that is going to be updated
-         * @param {"update" | "remove"} updateType
-         * @param {MorphContext} ctx the merge context
-         * @returns {boolean} true if the attribute should be ignored, false otherwise
-         */
-        function ignoreAttribute(attr, to, updateType, ctx) {
-            if(attr === 'value' && ctx.ignoreActiveValue && to === document.activeElement){
-                return true;
-            }
-            return ctx.callbacks.beforeAttributeUpdated(attr, to, updateType) === false;
-        }
-
-        /**
-         * syncs a given node with another node, copying over all attributes and
-         * inner element state from the 'from' node to the 'to' node
-         *
-         * @param {Node} from the element to copy attributes & state from
-         * @param {Node} to the element to copy attributes & state to
-         * @param {MorphContext} ctx the merge context
-         */
-        function syncNodeFrom(from, to, ctx) {
-            let type = from.nodeType
-
-            // if is an element type, sync the attributes from the
-            // new node into the new node
-            if (type === 1 /* element type */) {
-                const fromEl = /** @type {Element} */ (from);
-                const toEl = /** @type {Element} */ (to);
-                const fromAttributes = fromEl.attributes;
-                const toAttributes = toEl.attributes;
-                for (const fromAttribute of fromAttributes) {
-                    if (ignoreAttribute(fromAttribute.name, toEl, 'update', ctx)) {
-                        continue;
-                    }
-                    if (toEl.getAttribute(fromAttribute.name) !== fromAttribute.value) {
-                        toEl.setAttribute(fromAttribute.name, fromAttribute.value);
-                    }
-                }
-                // iterate backwards to avoid skipping over items when a delete occurs
-                for (let i = toAttributes.length - 1; 0 <= i; i--) {
-                    const toAttribute = toAttributes[i];
-
-                    // toAttributes is a live NamedNodeMap, so iteration+mutation is unsafe
-                    // e.g. custom element attribute callbacks can remove other attributes
-                    if (!toAttribute) continue;
-
-                    if (!fromEl.hasAttribute(toAttribute.name)) {
-                        if (ignoreAttribute(toAttribute.name, toEl, 'remove', ctx)) {
-                            continue;
-                        }
-                        toEl.removeAttribute(toAttribute.name);
-                    }
-                }
-            }
-
-            // sync text nodes
-            if (type === 8 /* comment */ || type === 3 /* text */) {
-                if (to.nodeValue !== from.nodeValue) {
-                    to.nodeValue = from.nodeValue;
-                }
-            }
-
-            if (!ignoreValueOfActiveElement(to, ctx)) {
-                // sync input values
-                syncInputValue(from, to, ctx);
-            }
-        }
-
-        /**
-         * @param {Element} from element to sync the value from
-         * @param {Element} to element to sync the value to
-         * @param {string} attributeName the attribute name
-         * @param {MorphContext} ctx the merge context
-         */
-        function syncBooleanAttribute(from, to, attributeName, ctx) {
-            // TODO: prefer set/getAttribute here
-            if (!(from instanceof Element && to instanceof Element)) return
-            // @ts-ignore this function is only used on boolean attrs that are reflected as dom properties
-            const fromLiveValue = from[attributeName], toLiveValue = to[attributeName];
-            if (fromLiveValue !== toLiveValue) {
-                let ignoreUpdate = ignoreAttribute(attributeName, to, 'update', ctx);
-                if (!ignoreUpdate) {
-                  // update attribute's associated DOM property
-                  // @ts-ignore this function is only used on boolean attrs that are reflected as dom properties
-                  to[attributeName] = from[attributeName];
-                }
-                if (fromLiveValue) {
-                    if (!ignoreUpdate) {
-                        // TODO: do we really want this? tests say so but it feels wrong
-                        to.setAttribute(attributeName, fromLiveValue);
-                    }
-                } else {
-                    if (!ignoreAttribute(attributeName, to, 'remove', ctx)) {
-                        to.removeAttribute(attributeName);
-                    }
-                }
-            }
-        }
-
-        /**
-         * NB: many bothans died to bring us information:
-         *
-         *  https://github.com/patrick-steele-idem/morphdom/blob/master/src/specialElHandlers.js
-         *  https://github.com/choojs/nanomorph/blob/master/lib/morph.jsL113
-         *
-         * @param {Node} from the element to sync the input value from
-         * @param {Node} to the element to sync the input value to
-         * @param {MorphContext} ctx the merge context
-         */
-        function syncInputValue(from, to, ctx) {
-            if (from instanceof HTMLInputElement &&
-                to instanceof HTMLInputElement &&
-                from.type !== 'file') {
-
-                let fromValue = from.value;
-                let toValue = to.value;
-
-                // sync boolean attributes
-                syncBooleanAttribute(from, to, 'checked', ctx);
-                syncBooleanAttribute(from, to, 'disabled', ctx);
-
-                if (!from.hasAttribute('value')) {
-                    if (!ignoreAttribute('value', to, 'remove', ctx)) {
-                        to.value = '';
-                        to.removeAttribute('value');
-                    }
-                } else if (fromValue !== toValue) {
-                    if (!ignoreAttribute('value', to, 'update', ctx)) {
-                        to.setAttribute('value', fromValue);
-                        to.value = fromValue;
-                    }
-                }
-            // TODO: QUESTION(1cg): this used to only check `from` unlike the other branches -- why?
-            // did I break something?
-            } else if (from instanceof HTMLOptionElement && to instanceof HTMLOptionElement) {
-                syncBooleanAttribute(from, to, 'selected', ctx)
-            } else if (from instanceof HTMLTextAreaElement && to instanceof HTMLTextAreaElement) {
-                let fromValue = from.value;
-                let toValue = to.value;
-                if (ignoreAttribute('value', to, 'update', ctx)) {
-                    return;
-                }
-                if (fromValue !== toValue) {
-                    to.value = fromValue;
-                }
-                if (to.firstChild && to.firstChild.nodeValue !== fromValue) {
-                    to.firstChild.nodeValue = fromValue
-                }
-            }
-        }
-
-
-        /**
-         * =============================================================================
-         *  The HEAD tag can be handled specially, either w/ a 'merge' or 'append' style
-         * =============================================================================
-         * @param {Element} newHeadTag
-         * @param {Element} currentHead
-         * @param {MorphContext} ctx
-         * @returns {Promise<void>[]}
-         */
-        function handleHeadElement(newHeadTag, currentHead, ctx) {
-            /**
-             * @type {Node[]}
-             */
-            let added = []
-            /**
-             * @type {Element[]}
-             */
-            let removed = []
-            /**
-             * @type {Element[]}
-             */
-            let preserved = []
-            /**
-             * @type {Element[]}
-             */
-            let nodesToAppend = []
-
-            let headMergeStyle = ctx.head.style;
-
-            // put all new head elements into a Map, by their outerHTML
-            let srcToNewHeadNodes = new Map();
-            for (const newHeadChild of newHeadTag.children) {
-                srcToNewHeadNodes.set(newHeadChild.outerHTML, newHeadChild);
-            }
-
-            // for each elt in the current head
-            for (const currentHeadElt of currentHead.children) {
-
-                // If the current head element is in the map
-                let inNewContent = srcToNewHeadNodes.has(currentHeadElt.outerHTML);
-                let isReAppended = ctx.head.shouldReAppend(currentHeadElt);
-                let isPreserved = ctx.head.shouldPreserve(currentHeadElt);
-                if (inNewContent || isPreserved) {
-                    if (isReAppended) {
-                        // remove the current version and let the new version replace it and re-execute
-                        removed.push(currentHeadElt);
-                    } else {
-                        // this element already exists and should not be re-appended, so remove it from
-                        // the new content map, preserving it in the DOM
-                        srcToNewHeadNodes.delete(currentHeadElt.outerHTML);
-                        preserved.push(currentHeadElt);
-                    }
-                } else {
-                    if (headMergeStyle === "append") {
-                        // we are appending and this existing element is not new content
-                        // so if and only if it is marked for re-append do we do anything
-                        if (isReAppended) {
-                            removed.push(currentHeadElt);
-                            nodesToAppend.push(currentHeadElt);
-                        }
-                    } else {
-                        // if this is a merge, we remove this content since it is not in the new head
-                        if (ctx.head.shouldRemove(currentHeadElt) !== false) {
-                            removed.push(currentHeadElt);
-                        }
-                    }
-                }
-            }
-
-            // Push the remaining new head elements in the Map into the
-            // nodes to append to the head tag
-            nodesToAppend.push(...srcToNewHeadNodes.values());
-            log("to append: ", nodesToAppend);
-
-            let promises = [];
-            for (const newNode of nodesToAppend) {
-                log("adding: ", newNode);
-                // TODO: This could theoretically be null, based on type
-                let newElt = /** @type {ChildNode} */ (
-                  document.createRange().createContextualFragment(newNode.outerHTML).firstChild);
-                log(newElt);
-                if (ctx.callbacks.beforeNodeAdded(newElt) !== false) {
-                    if (('href' in newElt && newElt.href) || ('src' in newElt && newElt.src)) {
-                        /** @type {(result?: any) => void} */ let resolve;
-                        let promise = new Promise(function (_resolve) {
-                            resolve = _resolve;
-                        });
-                        newElt.addEventListener('load', function () {
-                            resolve();
-                        });
-                        promises.push(promise);
-                    }
-                    currentHead.appendChild(newElt);
-                    ctx.callbacks.afterNodeAdded(newElt);
-                    added.push(newElt);
-                }
-            }
-
-            // remove all removed elements, after we have appended the new elements to avoid
-            // additional network requests for things like style sheets
-            for (const removedElement of removed) {
-                if (ctx.callbacks.beforeNodeRemoved(removedElement) !== false) {
-                    currentHead.removeChild(removedElement);
-                    ctx.callbacks.afterNodeRemoved(removedElement);
-                }
-            }
-
-            ctx.head.afterHeadMorphed(currentHead, {added: added, kept: preserved, removed: removed});
-            return promises;
-        }
-
-        //=============================================================================
-        // Misc
-        //=============================================================================
-
-        /**
-         * @param {any[]} _args
-         */
-        function log(..._args) {
-            //console.log(args);
-        }
-
-        function noOp() {
-        }
-
-
-        /**
-         * Deep merges the config object and the Idiomoroph.defaults object to
-         * produce a final configuration object
-         * @param {Config} config
-         * @returns {ConfigInternal}
-         */
-        function mergeDefaults(config) {
-            /**
-             * @type {ConfigInternal}
-             */
-            let finalConfig= Object.assign({}, defaults);
-
-            // copy top level stuff into final config
-            Object.assign(finalConfig, config);
-
-            // copy callbacks into final config (do this to deep merge the callbacks)
-            finalConfig.callbacks = Object.assign({}, defaults.callbacks, config.callbacks);
-
-            // copy head config into final config  (do this to deep merge the head)
-            finalConfig.head = Object.assign({}, defaults.head, config.head);
-
-            return finalConfig;
-        }
-
-        /**
-         *
-         * @param {Element} oldNode
-         * @param {Element} newContent
-         * @param {Config} config
-         * @returns {MorphContext}
-         */
-        function createMorphContext(oldNode, newContent, config) {
-            const mergedConfig = mergeDefaults(config);
-            return {
-                target: oldNode,
-                newContent: newContent,
-                config: mergedConfig,
-                morphStyle: mergedConfig.morphStyle,
-                ignoreActive: mergedConfig.ignoreActive,
-                ignoreActiveValue: mergedConfig.ignoreActiveValue,
-                idMap: createIdMap(oldNode, newContent),
-                deadIds: new Set(),
-                persistentIds: mergedConfig.twoPass ? createPersistentIds(oldNode, newContent) : new Set(),
-                pantry: mergedConfig.twoPass ? createPantry() : document.createElement("div"),
-                callbacks: mergedConfig.callbacks,
-                head: mergedConfig.head
-            }
-        }
-
-        function createPantry() {
-            const pantry = document.createElement("div");
-            pantry.hidden = true;
-            document.body.insertAdjacentElement("afterend", pantry);
-            return pantry;
-        }
-
-        /**
-         *
-         * @param {Node | null} node1
-         * @param {Node | null} node2
-         * @param {MorphContext} ctx
-         * @returns {boolean}
-         */
-        // TODO: The function handles this as if it's Element or null, but the function is called in
-        //   places where the arguments may be just a Node, not an Element
-        function isIdSetMatch(node1, node2, ctx) {
-            if (node1 == null || node2 == null) {
-                return false;
-            }
-            if ((node1 instanceof Element) && (node2 instanceof Element) &&
-                    node1.tagName === node2.tagName) {
-                if (node1.id !== "" && node1.id === node2.id) {
-                    return true;
-                } else {
-                    return getIdIntersectionCount(ctx, node1, node2) > 0;
-                }
-            }
-            return false;
-        }
-
-        /**
-         *
-         * @param {Node | null} oldNode
-         * @param {Node | null} newNode
-         * @returns {boolean}
-         */
-        function isSoftMatch(oldNode, newNode) {
-            if (oldNode == null || newNode == null) {
-                return false;
-            }
-            // ok to cast: if one is not element, `id` or `tagName` will be undefined and we'll compare that
-            // If oldNode has an `id` with possible state and it doesn't match newNode.id then avoid morphing
-            if ( /** @type {Element} */ (oldNode).id && /** @type {Element} */ (oldNode).id !== /** @type {Element} */ (newNode).id) {
-                return false;
-            }
-            return oldNode.nodeType === newNode.nodeType &&
-              /** @type {Element} */ (oldNode).tagName === /** @type {Element} */ (newNode).tagName
-        }
-
-        /**
-         *
-         * @param {Node} startInclusive
-         * @param {Node} endExclusive
-         * @param {MorphContext} ctx
-         * @returns {Node | null}
-         */
-        function removeNodesBetween(startInclusive, endExclusive, ctx) {
-            /** @type {Node | null} */ let cursor = startInclusive;
-            while (cursor !== endExclusive) {
-                let tempNode = /** @type {Node} */ (cursor);
-                // TODO: Prefer assigning to a new variable here or expand the type of startInclusive
-                //  to be Node | null
-                cursor = tempNode.nextSibling;
-                removeNode(tempNode, ctx);
-            }
-            removeIdsFromConsideration(ctx, endExclusive);
-            return endExclusive.nextSibling;
-        }
-
-
-        /**
-         * =============================================================================
-         *  Scans forward from the insertionPoint in the old parent looking for a potential id match
-         *  for the newChild.  We stop if we find a potential id match for the new child OR
-         *  if the number of potential id matches we are discarding is greater than the
-         *  potential id matches for the new child
-         * =============================================================================
-         * @param {Node} newContent
-         * @param {Node} oldParent
-         * @param {Node} newChild
-         * @param {Node} insertionPoint
-         * @param {MorphContext} ctx
-         * @returns {null | Node}
-         */
-        function findIdSetMatch(newContent, oldParent, newChild, insertionPoint, ctx) {
-
-            // max id matches we are willing to discard in our search
-            let newChildPotentialIdCount = getIdIntersectionCount(ctx, newChild, oldParent);
-
-            /**
-             * @type {Node | null}
-             */
-            let potentialMatch = null;
-
-            // only search forward if there is a possibility of an id match
-            if (newChildPotentialIdCount > 0) {
-
-                // TODO: This is ghosting the potentialMatch variable outside of this block.
-                //   Probably an error
-                potentialMatch = insertionPoint;
-                // if there is a possibility of an id match, scan forward
-                // keep track of the potential id match count we are discarding (the
-                // newChildPotentialIdCount must be greater than this to make it likely
-                // worth it)
-                let otherMatchCount = 0;
-                while (potentialMatch != null) {
-
-                    // If we have an id match, return the current potential match
-                    if (isIdSetMatch(newChild, potentialMatch, ctx)) {
-                        return potentialMatch;
-                    }
-
-                    // computer the other potential matches of this new content
-                    otherMatchCount += getIdIntersectionCount(ctx, potentialMatch, newContent);
-                    if (otherMatchCount > newChildPotentialIdCount) {
-                        // if we have more potential id matches in _other_ content, we
-                        // do not have a good candidate for an id match, so return null
-                        return null;
-                    }
-
-                    // advanced to the next old content child
-                    potentialMatch = potentialMatch.nextSibling;
-                }
-            }
-            return potentialMatch;
-        }
-
-
-        /**
-         * =============================================================================
-         *  Scans forward from the insertionPoint in the old parent looking for a potential soft match
-         *  for the newChild.  We stop if we find a potential soft match for the new child OR
-         *  if we find a potential id match in the old parents children OR if we find two
-         *  potential soft matches for the next two pieces of new content
-         * =============================================================================
-         * @param {Node} newContent
-         * @param {Node} oldParent
-         * @param {Node} newChild
-         * @param {Node} insertionPoint
-         * @param {MorphContext} ctx
-         * @returns {null | Node}
-         */
-        function findSoftMatch(newContent, oldParent, newChild, insertionPoint, ctx) {
-
-            /**
-             * @type {Node | null}
-             */
-            let potentialSoftMatch = insertionPoint;
-            /**
-             * @type {Node | null}
-             */
-            let nextSibling = newChild.nextSibling;
-            let siblingSoftMatchCount = 0;
-
-            while (potentialSoftMatch != null) {
-
-                if (getIdIntersectionCount(ctx, potentialSoftMatch, newContent) > 0) {
-                    // the current potential soft match has a potential id set match with the remaining new
-                    // content so bail out of looking
-                    return null;
-                }
-
-                // if we have a soft match with the current node, return it
-                if (isSoftMatch(potentialSoftMatch, newChild)) {
-                    return potentialSoftMatch;
-                }
-
-                if (isSoftMatch(potentialSoftMatch, nextSibling)) {
-                    // the next new node has a soft match with this node, so
-                    // increment the count of future soft matches
-                    siblingSoftMatchCount++;
-                    // ok to cast: if it was null it couldn't be a soft match
-                    nextSibling = /** @type {Node} */ (nextSibling).nextSibling;
-
-                    // If there are two future soft matches, bail to allow the siblings to soft match
-                    // so that we don't consume future soft matches for the sake of the current node
-                    if (siblingSoftMatchCount >= 2) {
-                        return null;
-                    }
-                }
-
-                // advanced to the next old content child
-                potentialSoftMatch = potentialSoftMatch.nextSibling;
-            }
-
-            return potentialSoftMatch;
-        }
-
-        /** @type {WeakSet<Node>} */
-        const generatedByIdiomorph = new WeakSet();
-
-        /**
-         *
-         * @param {string} newContent
-         * @returns {Node | null | DocumentFragment}
-         */
-        function parseContent(newContent) {
-            let parser = new DOMParser();
-
-            // remove svgs to avoid false-positive matches on head, etc.
-            let contentWithSvgsRemoved = newContent.replace(/<svg(\s[^>]*>|>)([\s\S]*?)<\/svg>/gim, '');
-
-            // if the newContent contains a html, head or body tag, we can simply parse it w/o wrapping
-            if (contentWithSvgsRemoved.match(/<\/html>/) || contentWithSvgsRemoved.match(/<\/head>/) || contentWithSvgsRemoved.match(/<\/body>/)) {
-                let content = parser.parseFromString(newContent, "text/html");
-                // if it is a full HTML document, return the document itself as the parent container
-                if (contentWithSvgsRemoved.match(/<\/html>/)) {
-                    generatedByIdiomorph.add(content);
-                    return content;
-                } else {
-                    // otherwise return the html element as the parent container
-                    let htmlElement = content.firstChild;
-                    if (htmlElement) {
-                        generatedByIdiomorph.add(htmlElement);
-                        return htmlElement;
-                    } else {
-                        return null;
-                    }
-                }
-            } else {
-                // if it is partial HTML, wrap it in a template tag to provide a parent element and also to help
-                // deal with touchy tags like tr, tbody, etc.
-                let responseDoc = parser.parseFromString("<body><template>" + newContent + "</template></body>", "text/html");
-                let content = /** @type {HTMLTemplateElement} */ (responseDoc.body.querySelector('template')).content;
-                generatedByIdiomorph.add(content);
-                return content
-            }
-        }
-
-        /**
-         *
-         * @param {null | Node | HTMLCollection | Node[] | Document & {generatedByIdiomorph:boolean}} newContent
-         * @returns {Element}
-         */
-        function normalizeContent(newContent) {
-            if (newContent == null) {
-                // noinspection UnnecessaryLocalVariableJS
-                const dummyParent = document.createElement('div');
-                return dummyParent;
-            } else if (generatedByIdiomorph.has(/** @type {Element} */ (newContent))) {
-                // the template tag created by idiomorph parsing can serve as a dummy parent
-                return /** @type {Element} */ (newContent);
-            } else if (newContent instanceof Node) {
-                // a single node is added as a child to a dummy parent
-                const dummyParent = document.createElement('div');
-                dummyParent.append(newContent);
-                return dummyParent;
-            } else {
-                // all nodes in the array or HTMLElement collection are consolidated under
-                // a single dummy parent element
-                const dummyParent = document.createElement('div');
-                for (const elt of [...newContent]) {
-                    dummyParent.append(elt);
-                }
-                return dummyParent;
-            }
-        }
-
-        /**
-         *
-         * @param {Node | null} previousSibling
-         * @param {Node} morphedNode
-         * @param {Node | null} nextSibling
-         * @returns {Node[]}
-         */
-        function insertSiblings(previousSibling, morphedNode, nextSibling) {
-            /**
-             * @type {Node[]}
-             */
-            let stack = []
-            /**
-             * @type {Node[]}
-             */
-            let added = []
-            while (previousSibling != null) {
-                stack.push(previousSibling);
-                previousSibling = previousSibling.previousSibling;
-            }
-            // Base the loop on the node variable, so that you do not need runtime checks for
-            // undefined value inside the loop
-            let node = stack.pop();
-            while (node !== undefined) {
-                added.push(node); // push added preceding siblings on in order and insert
-                morphedNode.parentElement?.insertBefore(node, morphedNode);
-                node = stack.pop();
-            }
-            added.push(morphedNode);
-            while (nextSibling != null) {
-                stack.push(nextSibling);
-                added.push(nextSibling); // here we are going in order, so push on as we scan, rather than add
-                nextSibling = nextSibling.nextSibling;
-            }
-            while (stack.length > 0) {
-                const node = /** @type {Node} */ (stack.pop());
-                morphedNode.parentElement?.insertBefore(node, morphedNode.nextSibling);
-            }
-            return added;
-        }
-
-        /**
-         *
-         * @param {Element} newContent
-         * @param {Element} oldNode
-         * @param {MorphContext} ctx
-         * @returns {Node | null}
-         */
-        function findBestNodeMatch(newContent, oldNode, ctx) {
-            /**
-             * @type {Node | null}
-             */
-            let currentElement;
-            currentElement = newContent.firstChild;
-            /**
-             * @type {Node | null}
-             */
-            let bestElement = currentElement;
-            let score = 0;
-            while (currentElement) {
-                let newScore = scoreElement(currentElement, oldNode, ctx);
-                if (newScore > score) {
-                    bestElement = currentElement;
-                    score = newScore;
-                }
-                currentElement = currentElement.nextSibling;
-            }
-            return bestElement;
-        }
-
-        /**
-         *
-         * @param {Node | null} node1
-         * @param {Element} node2
-         * @param {MorphContext} ctx
-         * @returns {number}
-         */
-        // TODO: The function handles node1 and node2 as if they are Elements but the function is
-        //   called in places where node1 and node2 may be just Nodes, not Elements
-        function scoreElement(node1, node2, ctx) {
-            if (isSoftMatch(node2, node1)) {
-                // ok to cast: isSoftMatch performs a null check
-                return .5 + getIdIntersectionCount(ctx, /** @type {Node} */ (node1), node2);
-            }
-            return 0;
-        }
-
-        /**
-         *
-         * @param {Node} tempNode
-         * @param {MorphContext} ctx
-         */
-        // TODO: The function handles tempNode as if it's Element but the function is called in
-        //   places where tempNode may be just a Node, not an Element
-        function removeNode(tempNode, ctx) {
-            removeIdsFromConsideration(ctx, tempNode)
-            // skip remove callbacks when we're going to be restoring this from the pantry in the second pass
-            if (ctx.config.twoPass && hasPersistentIdNodes(ctx, tempNode) && tempNode instanceof Element) {
-                moveToPantry(tempNode, ctx);
-            } else {
-                if (ctx.callbacks.beforeNodeRemoved(tempNode) === false) return;
-                tempNode.parentNode?.removeChild(tempNode);
-                ctx.callbacks.afterNodeRemoved(tempNode);
-            }
-        }
-
-        /**
-         *
-         * @param {Node} node
-         * @param {MorphContext} ctx
-         */
-        function moveToPantry(node, ctx) {
-            if (ctx.callbacks.beforeNodePantried(node) === false) return
-
-            Array.from(node.childNodes).forEach(child => {
-                moveToPantry(child, ctx);
-            });
-
-            // After processing children, process the current node
-            if (ctx.persistentIds.has(/** @type {Element} */ (node).id)) {
+      }
+    } else {
+      // if it is partial HTML, wrap it in a template tag to provide a parent element and also to help
+      // deal with touchy tags like tr, tbody, etc.
+      let responseDoc = parser.parseFromString(
+        "<body><template>" + newContent + "</template></body>",
+        "text/html",
+      );
+      let content = /** @type {HTMLTemplateElement} */ (
+        responseDoc.body.querySelector("template")
+      ).content;
+      generatedByIdiomorph.add(content);
+      return content;
+    }
+  }
+
+  /**
+   *
+   * @param {null | Node | HTMLCollection | Node[] | Document & {generatedByIdiomorph:boolean}} newContent
+   * @returns {Element}
+   */
+  function normalizeContent(newContent) {
+    if (newContent == null) {
+      // noinspection UnnecessaryLocalVariableJS
+      const dummyParent = document.createElement("div");
+      return dummyParent;
+    } else if (generatedByIdiomorph.has(/** @type {Element} */ (newContent))) {
+      // the template tag created by idiomorph parsing can serve as a dummy parent
+      return /** @type {Element} */ (newContent);
+    } else if (newContent instanceof Node) {
+      // a single node is added as a child to a dummy parent
+      const dummyParent = document.createElement("div");
+      dummyParent.append(newContent);
+      return dummyParent;
+    } else {
+      // all nodes in the array or HTMLElement collection are consolidated under
+      // a single dummy parent element
+      const dummyParent = document.createElement("div");
+      for (const elt of [...newContent]) {
+        dummyParent.append(elt);
+      }
+      return dummyParent;
+    }
+  }
+
+  /**
+   *
+   * @param {Node | null} previousSibling
+   * @param {Node} morphedNode
+   * @param {Node | null} nextSibling
+   * @returns {Node[]}
+   */
+  function insertSiblings(previousSibling, morphedNode, nextSibling) {
+    /**
+     * @type {Node[]}
+     */
+    let stack = [];
+    /**
+     * @type {Node[]}
+     */
+    let added = [];
+    while (previousSibling != null) {
+      stack.push(previousSibling);
+      previousSibling = previousSibling.previousSibling;
+    }
+    // Base the loop on the node variable, so that you do not need runtime checks for
+    // undefined value inside the loop
+    let node = stack.pop();
+    while (node !== undefined) {
+      added.push(node); // push added preceding siblings on in order and insert
+      morphedNode.parentElement?.insertBefore(node, morphedNode);
+      node = stack.pop();
+    }
+    added.push(morphedNode);
+    while (nextSibling != null) {
+      stack.push(nextSibling);
+      added.push(nextSibling); // here we are going in order, so push on as we scan, rather than add
+      nextSibling = nextSibling.nextSibling;
+    }
+    while (stack.length > 0) {
+      const node = /** @type {Node} */ (stack.pop());
+      morphedNode.parentElement?.insertBefore(node, morphedNode.nextSibling);
+    }
+    return added;
+  }
+
+  /**
+   *
+   * @param {Element} newContent
+   * @param {Element} oldNode
+   * @param {MorphContext} ctx
+   * @returns {Node | null}
+   */
+  function findBestNodeMatch(newContent, oldNode, ctx) {
+    /**
+     * @type {Node | null}
+     */
+    let currentElement;
+    currentElement = newContent.firstChild;
+    /**
+     * @type {Node | null}
+     */
+    let bestElement = currentElement;
+    let score = 0;
+    while (currentElement) {
+      let newScore = scoreElement(currentElement, oldNode, ctx);
+      if (newScore > score) {
+        bestElement = currentElement;
+        score = newScore;
+      }
+      currentElement = currentElement.nextSibling;
+    }
+    return bestElement;
+  }
+
+  /**
+   *
+   * @param {Node | null} node1
+   * @param {Element} node2
+   * @param {MorphContext} ctx
+   * @returns {number}
+   */
+  // TODO: The function handles node1 and node2 as if they are Elements but the function is
+  //   called in places where node1 and node2 may be just Nodes, not Elements
+  function scoreElement(node1, node2, ctx) {
+    if (isSoftMatch(node2, node1)) {
+      // ok to cast: isSoftMatch performs a null check
+      return (
+        0.5 + getIdIntersectionCount(ctx, /** @type {Node} */ (node1), node2)
+      );
+    }
+    return 0;
+  }
+
+  /**
+   *
+   * @param {Node} tempNode
+   * @param {MorphContext} ctx
+   */
+  // TODO: The function handles tempNode as if it's Element but the function is called in
+  //   places where tempNode may be just a Node, not an Element
+  function removeNode(tempNode, ctx) {
+    removeIdsFromConsideration(ctx, tempNode);
+    // skip remove callbacks when we're going to be restoring this from the pantry in the second pass
+    if (
+      ctx.config.twoPass &&
+      hasPersistentIdNodes(ctx, tempNode) &&
+      tempNode instanceof Element
+    ) {
+      moveToPantry(tempNode, ctx);
+    } else {
+      if (ctx.callbacks.beforeNodeRemoved(tempNode) === false) return;
+      tempNode.parentNode?.removeChild(tempNode);
+      ctx.callbacks.afterNodeRemoved(tempNode);
+    }
+  }
+
+  /**
+   *
+   * @param {Node} node
+   * @param {MorphContext} ctx
+   */
+  function moveToPantry(node, ctx) {
+    if (ctx.callbacks.beforeNodePantried(node) === false) return;
+
+    Array.from(node.childNodes).forEach((child) => {
+      moveToPantry(child, ctx);
+    });
+
+    // After processing children, process the current node
+    if (ctx.persistentIds.has(/** @type {Element} */ (node).id)) {
+      // @ts-ignore - use proposed moveBefore feature
+      if (ctx.pantry.moveBefore) {
+        // @ts-ignore - use proposed moveBefore feature
+        ctx.pantry.moveBefore(node, null);
+      } else {
+        ctx.pantry.insertBefore(node, null);
+      }
+    } else {
+      if (ctx.callbacks.beforeNodeRemoved(node) === false) return;
+      node.parentNode?.removeChild(node);
+      ctx.callbacks.afterNodeRemoved(node);
+    }
+  }
+
+  /**
+   *
+   * @param {Node | null} root
+   * @param {MorphContext} ctx
+   */
+  function restoreFromPantry(root, ctx) {
+    if (root instanceof Element) {
+      Array.from(ctx.pantry.children)
+        .reverse()
+        .forEach((element) => {
+          const matchElement = root.querySelector(`#${element.id}`);
+          if (matchElement) {
+            // @ts-ignore - use proposed moveBefore feature
+            if (matchElement.parentElement?.moveBefore) {
+              // @ts-ignore - use proposed moveBefore feature
+              matchElement.parentElement.moveBefore(element, matchElement);
+              while (matchElement.hasChildNodes()) {
                 // @ts-ignore - use proposed moveBefore feature
-                if (ctx.pantry.moveBefore) {
-                    // @ts-ignore - use proposed moveBefore feature
-                    ctx.pantry.moveBefore(node, null);
-                } else {
-                    ctx.pantry.insertBefore(node, null);
-                }
+                element.moveBefore(matchElement.firstChild, null);
+              }
             } else {
-                if (ctx.callbacks.beforeNodeRemoved(node) === false) return;
-                node.parentNode?.removeChild(node);
-                ctx.callbacks.afterNodeRemoved(node);
+              matchElement.before(element);
+              while (matchElement.firstChild) {
+                element.insertBefore(matchElement.firstChild, null);
+              }
             }
-        }
-
-        /**
-         *
-         * @param {Node | null} root
-         * @param {MorphContext} ctx
-         */
-        function restoreFromPantry(root, ctx) {
-            if (root instanceof Element) {
-                Array.from(ctx.pantry.children).reverse().forEach(element => {
-                    const matchElement = root.querySelector(`#${element.id}`);
-                    if (matchElement) {
-                        // @ts-ignore - use proposed moveBefore feature
-                        if (matchElement.parentElement?.moveBefore) {
-                            // @ts-ignore - use proposed moveBefore feature
-                            matchElement.parentElement.moveBefore(element, matchElement);
-                            while (matchElement.hasChildNodes()) {
-                                // @ts-ignore - use proposed moveBefore feature
-                                element.moveBefore(matchElement.firstChild, null);
-                            }
-                        } else {
-                            matchElement.before(element);
-                            while (matchElement.firstChild) {
-                                element.insertBefore(matchElement.firstChild, null)
-                            }
-                        }
-                        if (ctx.callbacks.beforeNodeMorphed(element, matchElement) !== false) {
-                            syncNodeFrom(matchElement, element, ctx);
-                            ctx.callbacks.afterNodeMorphed(element, matchElement);
-                        }
-                        matchElement.remove();
-                    }
-                });
-                ctx.pantry.remove();
+            if (
+              ctx.callbacks.beforeNodeMorphed(element, matchElement) !== false
+            ) {
+              syncNodeFrom(matchElement, element, ctx);
+              ctx.callbacks.afterNodeMorphed(element, matchElement);
             }
+            matchElement.remove();
+          }
+        });
+      ctx.pantry.remove();
+    }
+  }
+
+  //=============================================================================
+  // ID Set Functions
+  //=============================================================================
+
+  /**
+   *
+   * @param {MorphContext} ctx
+   * @param {string} id
+   * @returns {boolean}
+   */
+  function isIdInConsideration(ctx, id) {
+    return !ctx.deadIds.has(id);
+  }
+
+  /**
+   *
+   * @param {MorphContext} ctx
+   * @param {string} id
+   * @param {Node} targetNode
+   * @returns {boolean}
+   */
+  function idIsWithinNode(ctx, id, targetNode) {
+    let idSet = ctx.idMap.get(targetNode) || EMPTY_SET;
+    return idSet.has(id);
+  }
+
+  /**
+   *
+   * @param {MorphContext} ctx
+   * @param {Node} node
+   * @returns {void}
+   */
+  function removeIdsFromConsideration(ctx, node) {
+    let idSet = ctx.idMap.get(node) || EMPTY_SET;
+    for (const id of idSet) {
+      ctx.deadIds.add(id);
+    }
+  }
+
+  /**
+   *
+   * @param {MorphContext} ctx
+   * @param {Node} node
+   * @returns {boolean}
+   */
+  function hasPersistentIdNodes(ctx, node) {
+    for (const id of ctx.idMap.get(node) || EMPTY_SET) {
+      if (ctx.persistentIds.has(id)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   *
+   * @param {MorphContext} ctx
+   * @param {Node} node1
+   * @param {Node} node2
+   * @returns {number}
+   */
+  function getIdIntersectionCount(ctx, node1, node2) {
+    let sourceSet = ctx.idMap.get(node1) || EMPTY_SET;
+    let matchCount = 0;
+    for (const id of sourceSet) {
+      // a potential match is an id in the source and potentialIdsSet, but
+      // that has not already been merged into the DOM
+      if (isIdInConsideration(ctx, id) && idIsWithinNode(ctx, id, node2)) {
+        ++matchCount;
+      }
+    }
+    return matchCount;
+  }
+
+  /**
+   * @param {Element} content
+   * @returns {Element[]}
+   */
+  function nodesWithIds(content) {
+    let nodes = Array.from(content.querySelectorAll("[id]"));
+    if (content.id) {
+      nodes.push(content);
+    }
+    return nodes;
+  }
+
+  /**
+   * A bottom up algorithm that finds all elements with ids in the node
+   * argument and populates id sets for those nodes and all their parents, generating
+   * a set of ids contained within all nodes for the entire hierarchy in the DOM
+   *
+   * @param {Element} node
+   * @param {Map<Node, Set<string>>} idMap
+   */
+  function populateIdMapForNode(node, idMap) {
+    let nodeParent = node.parentElement;
+    for (const elt of nodesWithIds(node)) {
+      /**
+       * @type {Element|null}
+       */
+      let current = elt;
+      // walk up the parent hierarchy of that element, adding the id
+      // of element to the parent's id set
+      while (current !== nodeParent && current != null) {
+        let idSet = idMap.get(current);
+        // if the id set doesn't exist, create it and insert it in the  map
+        if (idSet == null) {
+          idSet = new Set();
+          idMap.set(current, idSet);
         }
+        idSet.add(elt.id);
+        current = current.parentElement;
+      }
+    }
+  }
 
-        //=============================================================================
-        // ID Set Functions
-        //=============================================================================
+  /**
+   * This function computes a map of nodes to all ids contained within that node (inclusive of the
+   * node).  This map can be used to ask if two nodes have intersecting sets of ids, which allows
+   * for a looser definition of "matching" than tradition id matching, and allows child nodes
+   * to contribute to a parent nodes matching.
+   *
+   * @param {Element} oldContent  the old content that will be morphed
+   * @param {Element} newContent  the new content to morph to
+   * @returns {Map<Node, Set<string>>} a map of nodes to id sets for the
+   */
+  function createIdMap(oldContent, newContent) {
+    /**
+     *
+     * @type {Map<Node, Set<string>>}
+     */
+    let idMap = new Map();
+    populateIdMapForNode(oldContent, idMap);
+    populateIdMapForNode(newContent, idMap);
+    return idMap;
+  }
 
-        /**
-         *
-         * @param {MorphContext} ctx
-         * @param {string} id
-         * @returns {boolean}
-         */
-        function isIdInConsideration(ctx, id) {
-            return !ctx.deadIds.has(id);
-        }
+  /**
+   * @param {Element} oldContent  the old content that will be morphed
+   * @param {Element} newContent  the new content to morph to
+   * @returns {Set<string>} the id set of all persistent nodes that exist in both old and new content
+   */
+  function createPersistentIds(oldContent, newContent) {
+    const toIdTagName = (node) => node.tagName + "#" + node.id;
+    const oldIdSet = new Set(nodesWithIds(oldContent).map(toIdTagName));
 
-        /**
-         *
-         * @param {MorphContext} ctx
-         * @param {string} id
-         * @param {Node} targetNode
-         * @returns {boolean}
-         */
-        function idIsWithinNode(ctx, id, targetNode) {
-            let idSet = ctx.idMap.get(targetNode) || EMPTY_SET;
-            return idSet.has(id);
-        }
+    let matchIdSet = new Set();
+    for (const newNode of nodesWithIds(newContent)) {
+      if (oldIdSet.has(toIdTagName(newNode))) {
+        matchIdSet.add(newNode.id);
+      }
+    }
+    return matchIdSet;
+  }
 
-        /**
-         *
-         * @param {MorphContext} ctx
-         * @param {Node} node
-         * @returns {void}
-         */
-        function removeIdsFromConsideration(ctx, node) {
-            let idSet = ctx.idMap.get(node) || EMPTY_SET;
-            for (const id of idSet) {
-                ctx.deadIds.add(id);
-            }
-        }
-
-        /**
-         *
-         * @param {MorphContext} ctx
-         * @param {Node} node
-         * @returns {boolean}
-         */
-        function hasPersistentIdNodes(ctx, node) {
-            for (const id of ctx.idMap.get(node) || EMPTY_SET) {
-                if (ctx.persistentIds.has(id)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        /**
-         *
-         * @param {MorphContext} ctx
-         * @param {Node} node1
-         * @param {Node} node2
-         * @returns {number}
-         */
-        function getIdIntersectionCount(ctx, node1, node2) {
-            let sourceSet = ctx.idMap.get(node1) || EMPTY_SET;
-            let matchCount = 0;
-            for (const id of sourceSet) {
-                // a potential match is an id in the source and potentialIdsSet, but
-                // that has not already been merged into the DOM
-                if (isIdInConsideration(ctx, id) && idIsWithinNode(ctx, id, node2)) {
-                    ++matchCount;
-                }
-            }
-            return matchCount;
-        }
-
-        /**
-         * @param {Element} content
-         * @returns {Element[]}
-         */
-        function nodesWithIds(content) {
-            let nodes = Array.from(content.querySelectorAll('[id]'));
-            if(content.id) {
-               nodes.push(content);
-            }
-            return nodes;
-        }
-
-        /**
-         * A bottom up algorithm that finds all elements with ids in the node
-         * argument and populates id sets for those nodes and all their parents, generating
-         * a set of ids contained within all nodes for the entire hierarchy in the DOM
-         *
-         * @param {Element} node
-         * @param {Map<Node, Set<string>>} idMap
-         */
-        function populateIdMapForNode(node, idMap) {
-            let nodeParent = node.parentElement;
-            for (const elt of nodesWithIds(node)) {
-                /**
-                 * @type {Element|null}
-                 */
-                let current = elt;
-                // walk up the parent hierarchy of that element, adding the id
-                // of element to the parent's id set
-                while (current !== nodeParent && current != null) {
-                    let idSet = idMap.get(current);
-                    // if the id set doesn't exist, create it and insert it in the  map
-                    if (idSet == null) {
-                        idSet = new Set();
-                        idMap.set(current, idSet);
-                    }
-                    idSet.add(elt.id);
-                    current = current.parentElement;
-                }
-            }
-        }
-
-        /**
-         * This function computes a map of nodes to all ids contained within that node (inclusive of the
-         * node).  This map can be used to ask if two nodes have intersecting sets of ids, which allows
-         * for a looser definition of "matching" than tradition id matching, and allows child nodes
-         * to contribute to a parent nodes matching.
-         *
-         * @param {Element} oldContent  the old content that will be morphed
-         * @param {Element} newContent  the new content to morph to
-         * @returns {Map<Node, Set<string>>} a map of nodes to id sets for the
-         */
-        function createIdMap(oldContent, newContent) {
-            /**
-             *
-             * @type {Map<Node, Set<string>>}
-             */
-            let idMap = new Map();
-            populateIdMapForNode(oldContent, idMap);
-            populateIdMapForNode(newContent, idMap);
-            return idMap;
-        }
-
-        /**
-         * @param {Element} oldContent  the old content that will be morphed
-         * @param {Element} newContent  the new content to morph to
-         * @returns {Set<string>} the id set of all persistent nodes that exist in both old and new content
-         */
-        function createPersistentIds(oldContent, newContent) {
-            const toIdTagName = node => node.tagName+'#'+node.id;
-            const oldIdSet = new Set(nodesWithIds(oldContent).map(toIdTagName));
-
-            let matchIdSet = new Set();
-            for (const newNode of nodesWithIds(newContent)) {
-                if (oldIdSet.has(toIdTagName(newNode))) {
-                    matchIdSet.add(newNode.id);
-                }
-            }
-            return matchIdSet;
-        }
-
-        //=============================================================================
-        // This is what ends up becoming the Idiomorph global object
-        //=============================================================================
-        return {
-            morph,
-            defaults
-        }
-    })();
+  //=============================================================================
+  // This is what ends up becoming the Idiomorph global object
+  //=============================================================================
+  return {
+    morph,
+    defaults,
+  };
+})();

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1,91 +1,94 @@
-describe("Bootstrap test", function(){
-    setup();
+describe("Bootstrap test", function () {
+  setup();
 
-    it('can morph content to content', function()
-    {
-        let btn1 = make('<button>Foo</button>')
-        let btn2 = make('<button>Bar</button>')
+  it("can morph content to content", function () {
+    let btn1 = make("<button>Foo</button>");
+    let btn2 = make("<button>Bar</button>");
 
-        Idiomorph.morph(btn1, btn2);
+    Idiomorph.morph(btn1, btn2);
 
-        btn1.innerHTML.should.equal(btn2.innerHTML);
-    });
+    btn1.innerHTML.should.equal(btn2.innerHTML);
+  });
 
-    it('can morph attributes', function()
-    {
-        let btn1 = make('<button class="foo" disabled>Foo</button>')
-        let btn2 = make('<button class="bar">Bar</button>')
+  it("can morph attributes", function () {
+    let btn1 = make('<button class="foo" disabled>Foo</button>');
+    let btn2 = make('<button class="bar">Bar</button>');
 
-        Idiomorph.morph(btn1, btn2);
+    Idiomorph.morph(btn1, btn2);
 
-        btn1.getAttribute("class").should.equal("bar");
-        should.equal(null, btn1.getAttribute("disabled"));
-    });
+    btn1.getAttribute("class").should.equal("bar");
+    should.equal(null, btn1.getAttribute("disabled"));
+  });
 
-    it('can morph children', function()
-    {
-        let div1 = make('<div><button class="foo" disabled>Foo</button></div>')
-        let btn1 = div1.querySelector('button');
-        let div2 = make('<div><button class="bar">Bar</button></div>')
-        let btn2 = div2.querySelector('button');
+  it("can morph children", function () {
+    let div1 = make('<div><button class="foo" disabled>Foo</button></div>');
+    let btn1 = div1.querySelector("button");
+    let div2 = make('<div><button class="bar">Bar</button></div>');
+    let btn2 = div2.querySelector("button");
 
-        Idiomorph.morph(div1, div2);
+    Idiomorph.morph(div1, div2);
 
-        btn1.getAttribute("class").should.equal("bar");
-        should.equal(null, btn1.getAttribute("disabled"));
-        btn1.innerHTML.should.equal(btn2.innerHTML);
-    });
+    btn1.getAttribute("class").should.equal("bar");
+    should.equal(null, btn1.getAttribute("disabled"));
+    btn1.innerHTML.should.equal(btn2.innerHTML);
+  });
 
-    it('basic deep morph works', function(done)
-    {
-        let div1 = make('<div id="root1"><div><div id="d1">A</div></div><div><div id="d2">B</div></div><div><div id="d3">C</div></div></div>')
+  it("basic deep morph works", function (done) {
+    let div1 = make(
+      '<div id="root1"><div><div id="d1">A</div></div><div><div id="d2">B</div></div><div><div id="d3">C</div></div></div>',
+    );
 
-        let d1 = div1.querySelector("#d1")
-        let d2 = div1.querySelector("#d2")
-        let d3 = div1.querySelector("#d3")
+    let d1 = div1.querySelector("#d1");
+    let d2 = div1.querySelector("#d2");
+    let d3 = div1.querySelector("#d3");
 
-        let morphTo = '<div id="root1"><div><div id="d2">E</div></div><div><div id="d3">F</div></div><div><div id="d1">D</div></div></div>';
-        let div2 = make(morphTo)
+    let morphTo =
+      '<div id="root1"><div><div id="d2">E</div></div><div><div id="d3">F</div></div><div><div id="d1">D</div></div></div>';
+    let div2 = make(morphTo);
 
-        print(div1);
-        Idiomorph.morph(div1, div2);
-        print(div1);
+    print(div1);
+    Idiomorph.morph(div1, div2);
+    print(div1);
 
-        // first paragraph should have been discarded in favor of later matches
-        d1.innerHTML.should.not.equal("D");
+    // first paragraph should have been discarded in favor of later matches
+    d1.innerHTML.should.not.equal("D");
 
-        // second and third paragraph should have morphed
-        d2.innerHTML.should.equal("E");
-        d3.innerHTML.should.equal("F");
+    // second and third paragraph should have morphed
+    d2.innerHTML.should.equal("E");
+    d3.innerHTML.should.equal("F");
 
-        div1.outerHTML.should.equal(morphTo)
+    div1.outerHTML.should.equal(morphTo);
 
-        // // debugging output
-        // console.log(morphTo);
-        // console.log(div1.outerHTML);
+    // // debugging output
+    // console.log(morphTo);
+    // console.log(div1.outerHTML);
 
-        // setTimeout(()=> {
-        //     console.log("idiomorph mutations : ", div1.mutations);
-               done();
-        // }, 0)
-    });
+    // setTimeout(()=> {
+    //     console.log("idiomorph mutations : ", div1.mutations);
+    done();
+    // }, 0)
+  });
 
-    it('deep morphdom does not work ideally', function(done)
-    {
-        let div1 = make('<div id="root"><div><div id="d1">A</div></div><div><div id="d2">B</div></div><div><div id="d3">C</div></div></div>')
+  it("deep morphdom does not work ideally", function (done) {
+    let div1 = make(
+      '<div id="root"><div><div id="d1">A</div></div><div><div id="d2">B</div></div><div><div id="d3">C</div></div></div>',
+    );
 
-        let d1 = div1.querySelector("#d1")
-        let d2 = div1.querySelector("#d2")
-        let d3 = div1.querySelector("#d3")
+    let d1 = div1.querySelector("#d1");
+    let d2 = div1.querySelector("#d2");
+    let d3 = div1.querySelector("#d3");
 
-        morphdom(div1, '<div id="root2"><div><div id="d2">E</div></div><div><div id="d3">F</div></div><div><div id="d1">D</div></div></div>', {});
+    morphdom(
+      div1,
+      '<div id="root2"><div><div id="d2">E</div></div><div><div id="d3">F</div></div><div><div id="d1">D</div></div></div>',
+      {},
+    );
 
-        // // debugging output
-        // setTimeout(()=> {
-        //     console.log("morphdom mutations : ", div1.mutations);
-               done();
-        // }, 0)
-        // print(div1);
-    });
-
-})
+    // // debugging output
+    // setTimeout(()=> {
+    //     console.log("morphdom mutations : ", div1.mutations);
+    done();
+    // }, 0)
+    // print(div1);
+  });
+});

--- a/test/core.js
+++ b/test/core.js
@@ -1,437 +1,435 @@
-describe("Core morphing tests", function(){
-    setup();
+describe("Core morphing tests", function () {
+  setup();
 
-    it('morphs outerHTML as content properly when argument is null', function()
-    {
-        let initial = make("<button>Foo</button>");
-        Idiomorph.morph(initial, null, {morphStyle:'outerHTML'});
-        initial.isConnected.should.equal(false);
+  it("morphs outerHTML as content properly when argument is null", function () {
+    let initial = make("<button>Foo</button>");
+    Idiomorph.morph(initial, null, { morphStyle: "outerHTML" });
+    initial.isConnected.should.equal(false);
+  });
+
+  it("morphs outerHTML as content properly when argument is single node", function () {
+    let initial = make("<button>Foo</button>");
+    let finalSrc = "<button>Bar</button>";
+    let final = make(finalSrc);
+    Idiomorph.morph(initial, final, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal("<button>Bar</button>");
+  });
+
+  it("morphs outerHTML as content properly when argument is string", function () {
+    let initial = make("<button>Foo</button>");
+    let finalSrc = "<button>Bar</button>";
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal("<button>Bar</button>");
+  });
+
+  it("morphs outerHTML as content properly when argument is an HTMLElementCollection", function () {
+    let initial = make("<button>Foo</button>");
+    let finalSrc = "<div><button>Bar</button></div>";
+    let final = make(finalSrc).children;
+    Idiomorph.morph(initial, final, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal("<button>Bar</button>");
+  });
+
+  it("morphs outerHTML as content properly when argument is an Array", function () {
+    let initial = make("<button>Foo</button>");
+    let finalSrc = "<div><button>Bar</button></div>";
+    let final = [...make(finalSrc).children];
+    Idiomorph.morph(initial, final, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal("<button>Bar</button>");
+  });
+
+  it("morphs outerHTML as content properly when argument is HTMLElementCollection with siblings", function () {
+    let parent = make("<div><button>Foo</button></div>");
+    let initial = parent.querySelector("button");
+    let finalSrc = "<p>Foo</p><button>Bar</button><p>Bar</p>";
+    let final = makeElements(finalSrc);
+    Idiomorph.morph(initial, final, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal("<button>Bar</button>");
+    initial.parentElement.innerHTML.should.equal(
+      "<p>Foo</p><button>Bar</button><p>Bar</p>",
+    );
+  });
+
+  it("morphs outerHTML as content properly when argument is an Array with siblings", function () {
+    let parent = make("<div><button>Foo</button></div>");
+    let initial = parent.querySelector("button");
+    let finalSrc = "<p>Foo</p><button>Bar</button><p>Bar</p>";
+    let final = [...makeElements(finalSrc)];
+    Idiomorph.morph(initial, final, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal("<button>Bar</button>");
+    initial.parentElement.innerHTML.should.equal(
+      "<p>Foo</p><button>Bar</button><p>Bar</p>",
+    );
+  });
+
+  it("morphs outerHTML as content properly when argument is string", function () {
+    let parent = make("<div><button>Foo</button></div>");
+    let initial = parent.querySelector("button");
+    let finalSrc = "<p>Foo</p><button>Bar</button><p>Bar</p>";
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal("<button>Bar</button>");
+    initial.parentElement.innerHTML.should.equal(
+      "<p>Foo</p><button>Bar</button><p>Bar</p>",
+    );
+  });
+
+  it("morphs outerHTML as content properly when argument is string with multiple siblings", function () {
+    let parent = make("<div><button>Foo</button></div>");
+    let initial = parent.querySelector("button");
+    let finalSrc =
+      "<p>Doh</p><p>Foo</p><button>Bar</button><p>Bar</p><p>Ray</p>";
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal("<button>Bar</button>");
+    initial.parentElement.innerHTML.should.equal(
+      "<p>Doh</p><p>Foo</p><button>Bar</button><p>Bar</p><p>Ray</p>",
+    );
+  });
+
+  it("morphs innerHTML as content properly when argument is null", function () {
+    let initial = make("<div>Foo</div>");
+    Idiomorph.morph(initial, null, { morphStyle: "innerHTML" });
+    initial.outerHTML.should.equal("<div></div>");
+  });
+
+  it("morphs innerHTML as content properly when argument is single node", function () {
+    let initial = make("<div>Foo</div>");
+    let finalSrc = "<button>Bar</button>";
+    let final = make(finalSrc);
+    Idiomorph.morph(initial, final, { morphStyle: "innerHTML" });
+    initial.outerHTML.should.equal("<div><button>Bar</button></div>");
+  });
+
+  it("morphs innerHTML as content properly when argument is string", function () {
+    let initial = make("<button>Foo</button>");
+    let finalSrc = "<button>Bar</button>";
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "innerHTML" });
+    initial.outerHTML.should.equal("<button><button>Bar</button></button>");
+  });
+
+  it("morphs innerHTML as content properly when argument is an HTMLElementCollection", function () {
+    let initial = make("<button>Foo</button>");
+    let finalSrc = "<div><button>Bar</button></div>";
+    let final = make(finalSrc).children;
+    Idiomorph.morph(initial, final, { morphStyle: "innerHTML" });
+    initial.outerHTML.should.equal("<button><button>Bar</button></button>");
+  });
+
+  it("morphs innerHTML as content properly when argument is an Array", function () {
+    let initial = make("<button>Foo</button>");
+    let finalSrc = "<div><button>Bar</button></div>";
+    let final = [...make(finalSrc).children];
+    Idiomorph.morph(initial, final, { morphStyle: "innerHTML" });
+    initial.outerHTML.should.equal("<button><button>Bar</button></button>");
+  });
+
+  it("morphs innerHTML as content properly when argument is empty array", function () {
+    let initial = make("<div>Foo</div>");
+    Idiomorph.morph(initial, [], { morphStyle: "innerHTML" });
+    initial.outerHTML.should.equal("<div></div>");
+  });
+
+  it("errors on bad morphStyle", function () {
+    (() => {
+      Idiomorph.morph(make("<p>"), [], { morphStyle: "magic" });
+    }).should.throw("Do not understand how to morph style magic");
+  });
+
+  it("can morph a template tag properly", function () {
+    let initial = make("<template data-old>Foo</template>");
+    let final = make("<template data-new>Bar</template>");
+    Idiomorph.morph(initial, final);
+    initial.outerHTML.should.equal(final.outerHTML);
+  });
+
+  it("ignores active element when ignoreActive set to true", function () {
+    let initialSource = "<div><div id='d1'>Foo</div><input id='i1'></div>";
+    getWorkArea().innerHTML = initialSource;
+    let i1 = document.getElementById("i1");
+    i1.focus();
+    let d1 = document.getElementById("d1");
+    i1.value = "asdf";
+    let finalSource = "<div><div id='d1'>Bar</div><input id='i1'></div>";
+    Idiomorph.morph(getWorkArea(), finalSource, {
+      morphStyle: "innerHTML",
+      ignoreActive: true,
     });
+    d1.innerText.should.equal("Bar");
+    i1.value.should.equal("asdf");
+  });
 
-    it('morphs outerHTML as content properly when argument is single node', function()
-    {
-        let initial = make("<button>Foo</button>");
-        let finalSrc = "<button>Bar</button>";
-        let final = make(finalSrc);
-        Idiomorph.morph(initial, final, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal("<button>Bar</button>");
+  it("can morph a body tag properly", function () {
+    let initial = parseHTML("<body>Foo</body>");
+    let finalSrc = '<body foo="bar">Foo</body>';
+    let final = parseHTML(finalSrc);
+    Idiomorph.morph(initial.body, final.body);
+    initial.body.outerHTML.should.equal(finalSrc);
+  });
+
+  it("can morph a full document properly", function () {
+    let initial = parseHTML("<html><body>Foo</body></html>");
+    let finalSrc =
+      '<html foo="bar"><head></head><body foo="bar">Foo</body></html>';
+    Idiomorph.morph(initial, finalSrc);
+    initial.documentElement.outerHTML.should.equal(finalSrc);
+  });
+
+  it("ignores active input value when ignoreActiveValue is true", function () {
+    let parent = make("<div><input value='foo'></div>");
+    document.body.append(parent);
+
+    let initial = parent.querySelector("input");
+
+    // morph
+    let finalSrc = '<input value="bar">';
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal('<input value="bar">');
+
+    initial.focus();
+
+    document.activeElement.should.equal(initial);
+
+    let finalSrc2 = '<input class="foo" value="doh">';
+    Idiomorph.morph(initial, finalSrc2, {
+      morphStyle: "outerHTML",
+      ignoreActiveValue: true,
     });
+    initial.value.should.equal("bar");
+    initial.classList.value.should.equal("foo");
 
-    it('morphs outerHTML as content properly when argument is string', function()
-    {
-        let initial = make("<button>Foo</button>");
-        let finalSrc = "<button>Bar</button>";
-        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal("<button>Bar</button>");
+    document.body.removeChild(parent);
+  });
+
+  it("does not ignore body when ignoreActiveValue is true and no element has focus", function () {
+    let parent = make("<div><input value='foo'></div>");
+    document.body.append(parent);
+
+    let initial = parent.querySelector("input");
+
+    // morph
+    let finalSrc = '<input value="bar">';
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal('<input value="bar">');
+
+    document.activeElement.should.equal(document.body);
+
+    let finalSrc2 = '<input class="foo" value="doh">';
+    Idiomorph.morph(initial, finalSrc2, {
+      morphStyle: "outerHTML",
+      ignoreActiveValue: true,
     });
+    initial.value.should.equal("doh");
+    initial.classList.value.should.equal("foo");
 
-    it('morphs outerHTML as content properly when argument is an HTMLElementCollection', function()
-    {
-        let initial = make("<button>Foo</button>");
-        let finalSrc = "<div><button>Bar</button></div>";
-        let final = make(finalSrc).children;
-        Idiomorph.morph(initial, final, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal("<button>Bar</button>");
+    document.body.removeChild(parent);
+  });
+
+  it("can ignore attributes w/ the beforeAttributeUpdated callback", function () {
+    let parent = make("<div><input value='foo'></div>");
+    document.body.append(parent);
+
+    let initial = parent.querySelector("input");
+
+    // morph
+    let finalSrc = '<input value="bar">';
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal('<input value="bar">');
+
+    let finalSrc2 = '<input class="foo" value="doh">';
+    Idiomorph.morph(initial, finalSrc2, {
+      morphStyle: "outerHTML",
+      callbacks: {
+        beforeAttributeUpdated: function (attr) {
+          if (attr === "value") {
+            return false;
+          }
+        },
+      },
     });
+    initial.value.should.equal("bar");
+    initial.classList.value.should.equal("foo");
 
-    it('morphs outerHTML as content properly when argument is an Array', function()
-    {
-        let initial = make("<button>Foo</button>");
-        let finalSrc = "<div><button>Bar</button></div>";
-        let final = [...make(finalSrc).children];
-        Idiomorph.morph(initial, final, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal("<button>Bar</button>");
+    document.body.removeChild(parent);
+  });
+
+  it("can ignore attributes w/ the beforeAttributeUpdated callback 2", function () {
+    let parent = make("<div><input value='foo'></div>");
+    document.body.append(parent);
+
+    let initial = parent.querySelector("input");
+
+    // morph
+    let finalSrc = '<input value="bar">';
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal('<input value="bar">');
+
+    let finalSrc2 = '<input class="foo" value="doh">';
+    Idiomorph.morph(initial, finalSrc2, {
+      morphStyle: "outerHTML",
+      callbacks: {
+        beforeAttributeUpdated: function (attr) {
+          if (attr === "class") {
+            return false;
+          }
+        },
+      },
     });
+    initial.value.should.equal("doh");
+    initial.classList.value.should.equal("");
 
-    it('morphs outerHTML as content properly when argument is HTMLElementCollection with siblings', function()
-    {
-        let parent = make("<div><button>Foo</button></div>");
-        let initial = parent.querySelector("button");
-        let finalSrc = "<p>Foo</p><button>Bar</button><p>Bar</p>";
-        let final = makeElements(finalSrc);
-        Idiomorph.morph(initial, final, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal("<button>Bar</button>");
-        initial.parentElement.innerHTML.should.equal("<p>Foo</p><button>Bar</button><p>Bar</p>");
+    document.body.removeChild(parent);
+  });
+
+  it("can prevent element addition w/ the beforeNodeAdded callback", function () {
+    let parent = make("<div><p>1</p><p>2</p></div>");
+    document.body.append(parent);
+
+    // morph
+    let finalSrc = "<p>1</p><p>2</p><p>3</p><p>4</p>";
+
+    Idiomorph.morph(parent, finalSrc, {
+      morphStyle: "innerHTML",
+      callbacks: {
+        beforeNodeAdded(node) {
+          if (node.outerHTML === "<p>3</p>") return false;
+        },
+      },
     });
+    parent.innerHTML.should.equal("<p>1</p><p>2</p><p>4</p>");
 
-    it('morphs outerHTML as content properly when argument is an Array with siblings', function()
-    {
-        let parent = make("<div><button>Foo</button></div>");
-        let initial = parent.querySelector("button");
-        let finalSrc = "<p>Foo</p><button>Bar</button><p>Bar</p>";
-        let final = [...makeElements(finalSrc)];
-        Idiomorph.morph(initial, final, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal("<button>Bar</button>");
-        initial.parentElement.innerHTML.should.equal("<p>Foo</p><button>Bar</button><p>Bar</p>");
+    document.body.removeChild(parent);
+  });
+
+  it("ignores active textarea value when ignoreActiveValue is true", function () {
+    let parent = make("<div><textarea>foo</textarea></div>");
+    document.body.append(parent);
+    let initial = parent.querySelector("textarea");
+
+    let finalSrc = "<textarea>bar</textarea>";
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal("<textarea>bar</textarea>");
+
+    initial.focus();
+
+    document.activeElement.should.equal(initial);
+
+    let finalSrc2 = '<textarea class="foo">doh</textarea>';
+    Idiomorph.morph(initial, finalSrc2, {
+      morphStyle: "outerHTML",
+      ignoreActiveValue: true,
     });
+    initial.outerHTML.should.equal('<textarea class="foo">bar</textarea>');
 
-    it('morphs outerHTML as content properly when argument is string', function()
-    {
-        let parent = make("<div><button>Foo</button></div>");
-        let initial = parent.querySelector("button");
-        let finalSrc = "<p>Foo</p><button>Bar</button><p>Bar</p>";
-        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal("<button>Bar</button>");
-        initial.parentElement.innerHTML.should.equal("<p>Foo</p><button>Bar</button><p>Bar</p>");
+    document.body.removeChild(parent);
+  });
+
+  it("can morph input value properly because value property is special and doesnt reflect", function () {
+    let initial = make('<div><input value="foo"></div>');
+    let final = make('<input value="foo">');
+    final.value = "bar";
+    Idiomorph.morph(initial, final, { morphStyle: "innerHTML" });
+    initial.innerHTML.should.equal('<input value="bar">');
+  });
+
+  it("can morph textarea value properly because value property is special and doesnt reflect", function () {
+    let initial = make("<textarea>foo</textarea>");
+    let final = make("<textarea>foo</textarea>");
+    final.value = "bar";
+    Idiomorph.morph(initial, final, { morphStyle: "outerHTML" });
+    initial.value.should.equal("bar");
+  });
+
+  it("specially considers textarea value property in beforeAttributeUpdated hook because value property is special and doesnt reflect", function () {
+    let initial = make("<div><textarea>foo</textarea></div>");
+    let final = make("<textarea>foo</textarea>");
+    final.value = "bar";
+    Idiomorph.morph(initial, final, {
+      morphStyle: "innerHTML",
+      callbacks: {
+        beforeAttributeUpdated: (attr, to, updatetype) => false,
+      },
     });
-
-    it('morphs outerHTML as content properly when argument is string with multiple siblings', function()
-    {
-        let parent = make("<div><button>Foo</button></div>");
-        let initial = parent.querySelector("button");
-        let finalSrc = "<p>Doh</p><p>Foo</p><button>Bar</button><p>Bar</p><p>Ray</p>";
-        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal("<button>Bar</button>");
-        initial.parentElement.innerHTML.should.equal("<p>Doh</p><p>Foo</p><button>Bar</button><p>Bar</p><p>Ray</p>");
-    });
-
-    it('morphs innerHTML as content properly when argument is null', function()
-    {
-        let initial = make("<div>Foo</div>");
-        Idiomorph.morph(initial, null, {morphStyle:'innerHTML'});
-        initial.outerHTML.should.equal("<div></div>");
-    });
-
-    it('morphs innerHTML as content properly when argument is single node', function()
-    {
-        let initial = make("<div>Foo</div>");
-        let finalSrc = "<button>Bar</button>";
-        let final = make(finalSrc);
-        Idiomorph.morph(initial, final, {morphStyle:'innerHTML'});
-        initial.outerHTML.should.equal("<div><button>Bar</button></div>");
-    });
-
-    it('morphs innerHTML as content properly when argument is string', function()
-    {
-        let initial = make("<button>Foo</button>");
-        let finalSrc = "<button>Bar</button>";
-        Idiomorph.morph(initial, finalSrc, {morphStyle:'innerHTML'});
-        initial.outerHTML.should.equal("<button><button>Bar</button></button>");
-    });
-
-    it('morphs innerHTML as content properly when argument is an HTMLElementCollection', function()
-    {
-        let initial = make("<button>Foo</button>");
-        let finalSrc = "<div><button>Bar</button></div>";
-        let final = make(finalSrc).children;
-        Idiomorph.morph(initial, final, {morphStyle:'innerHTML'});
-        initial.outerHTML.should.equal("<button><button>Bar</button></button>");
-    });
-
-    it('morphs innerHTML as content properly when argument is an Array', function()
-    {
-        let initial = make("<button>Foo</button>");
-        let finalSrc = "<div><button>Bar</button></div>";
-        let final = [...make(finalSrc).children];
-        Idiomorph.morph(initial, final, {morphStyle:'innerHTML'});
-        initial.outerHTML.should.equal("<button><button>Bar</button></button>");
-    });
-
-    it('morphs innerHTML as content properly when argument is empty array', function()
-    {
-        let initial = make("<div>Foo</div>");
-        Idiomorph.morph(initial, [], {morphStyle:'innerHTML'});
-        initial.outerHTML.should.equal("<div></div>");
-    });
-
-    it('errors on bad morphStyle', function()
-    {
-        (() => {
-            Idiomorph.morph(make("<p>"), [], {morphStyle:'magic'});
-        }).should.throw("Do not understand how to morph style magic");
-    });
-
-    it('can morph a template tag properly', function()
-    {
-      let initial = make("<template data-old>Foo</template>");
-      let final = make("<template data-new>Bar</template>");
-      Idiomorph.morph(initial, final);
-      initial.outerHTML.should.equal(final.outerHTML);
-    });
-
-    it('ignores active element when ignoreActive set to true', function()
-    {
-        let initialSource = "<div><div id='d1'>Foo</div><input id='i1'></div>";
-        getWorkArea().innerHTML = initialSource;
-        let i1 = document.getElementById('i1');
-        i1.focus();
-        let d1 = document.getElementById('d1');
-        i1.value = "asdf";
-        let finalSource = "<div><div id='d1'>Bar</div><input id='i1'></div>";
-        Idiomorph.morph(getWorkArea(), finalSource, {morphStyle:'innerHTML', ignoreActive:true});
-        d1.innerText.should.equal("Bar")
-        i1.value.should.equal("asdf")
-    });
-
-    it('can morph a body tag properly', function()
-    {
-        let initial = parseHTML("<body>Foo</body>");
-        let finalSrc = '<body foo="bar">Foo</body>';
-        let final = parseHTML(finalSrc);
-        Idiomorph.morph(initial.body, final.body);
-        initial.body.outerHTML.should.equal(finalSrc);
-
-    });
-
-    it('can morph a full document properly', function()
-    {
-        let initial = parseHTML("<html><body>Foo</body></html>");
-        let finalSrc = '<html foo="bar"><head></head><body foo="bar">Foo</body></html>';
-        Idiomorph.morph(initial, finalSrc);
-        initial.documentElement.outerHTML.should.equal(finalSrc);
-    });
-
-    it('ignores active input value when ignoreActiveValue is true', function()
-    {
-        let parent = make("<div><input value='foo'></div>");
-        document.body.append(parent);
-
-        let initial = parent.querySelector("input");
-
-        // morph
-        let finalSrc = '<input value="bar">';
-        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal('<input value="bar">');
-
-        initial.focus();
-
-        document.activeElement.should.equal(initial);
-
-        let finalSrc2 = '<input class="foo" value="doh">';
-        Idiomorph.morph(initial, finalSrc2, {morphStyle:'outerHTML', ignoreActiveValue: true});
-        initial.value.should.equal('bar');
-        initial.classList.value.should.equal('foo');
-
-        document.body.removeChild(parent);
-    });
-
-    it('does not ignore body when ignoreActiveValue is true and no element has focus', function()
-    {
-        let parent = make("<div><input value='foo'></div>");
-        document.body.append(parent);
-
-        let initial = parent.querySelector("input");
-
-        // morph
-        let finalSrc = '<input value="bar">';
-        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal('<input value="bar">');
-
-        document.activeElement.should.equal(document.body);
-
-        let finalSrc2 = '<input class="foo" value="doh">';
-        Idiomorph.morph(initial, finalSrc2, {morphStyle:'outerHTML', ignoreActiveValue: true});
-        initial.value.should.equal('doh');
-        initial.classList.value.should.equal('foo');
-
-        document.body.removeChild(parent);
-    });
-
-    it('can ignore attributes w/ the beforeAttributeUpdated callback', function()
-    {
-        let parent = make("<div><input value='foo'></div>");
-        document.body.append(parent);
-
-        let initial = parent.querySelector("input");
-
-        // morph
-        let finalSrc = '<input value="bar">';
-        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal('<input value="bar">');
-
-        let finalSrc2 = '<input class="foo" value="doh">';
-        Idiomorph.morph(initial, finalSrc2, {morphStyle:'outerHTML', callbacks : {
-            beforeAttributeUpdated: function(attr){
-                if (attr === 'value') {
-                    return false;
-                }
-            }
-        }});
-        initial.value.should.equal('bar');
-        initial.classList.value.should.equal('foo');
-
-        document.body.removeChild(parent);
-    });
-
-    it('can ignore attributes w/ the beforeAttributeUpdated callback 2', function()
-    {
-        let parent = make("<div><input value='foo'></div>");
-        document.body.append(parent);
-
-        let initial = parent.querySelector("input");
-
-        // morph
-        let finalSrc = '<input value="bar">';
-        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal('<input value="bar">');
-
-        let finalSrc2 = '<input class="foo" value="doh">';
-        Idiomorph.morph(initial, finalSrc2, {morphStyle:'outerHTML', callbacks : {
-            beforeAttributeUpdated: function(attr){
-                if (attr === 'class') {
-                    return false;
-                }
-            }
-        }});
-        initial.value.should.equal('doh');
-        initial.classList.value.should.equal('');
-
-        document.body.removeChild(parent);
-    });
-
-    it('can prevent element addition w/ the beforeNodeAdded callback', function() {
-        let parent = make("<div><p>1</p><p>2</p></div>");
-        document.body.append(parent);
-
-        // morph
-        let finalSrc = "<p>1</p><p>2</p><p>3</p><p>4</p>";
-
-        Idiomorph.morph(parent, finalSrc, {morphStyle:'innerHTML', callbacks : {
-            beforeNodeAdded(node) {
-              if(node.outerHTML === "<p>3</p>") return false
-            }
-        }});
-        parent.innerHTML.should.equal("<p>1</p><p>2</p><p>4</p>");
-
-        document.body.removeChild(parent);
-    });
-
-    it('ignores active textarea value when ignoreActiveValue is true', function()
-    {
-        let parent = make("<div><textarea>foo</textarea></div>");
-        document.body.append(parent);
-        let initial = parent.querySelector("textarea");
-
-        let finalSrc = '<textarea>bar</textarea>';
-        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal('<textarea>bar</textarea>');
-
-        initial.focus();
-
-        document.activeElement.should.equal(initial);
-
-        let finalSrc2 = '<textarea class="foo">doh</textarea>';
-        Idiomorph.morph(initial, finalSrc2, {morphStyle:'outerHTML', ignoreActiveValue: true});
-        initial.outerHTML.should.equal('<textarea class="foo">bar</textarea>');
-
-        document.body.removeChild(parent);
-    });
-
-    it('can morph input value properly because value property is special and doesnt reflect', function()
-    {
-        let initial = make('<div><input value="foo"></div>');
-        let final = make('<input value="foo">');
-        final.value = "bar";
-        Idiomorph.morph(initial, final, {morphStyle:'innerHTML'});
-        initial.innerHTML.should.equal('<input value="bar">');
-    });
-
-    it('can morph textarea value properly because value property is special and doesnt reflect', function()
-    {
-        let initial = make('<textarea>foo</textarea>');
-        let final = make('<textarea>foo</textarea>');
-        final.value = "bar";
-        Idiomorph.morph(initial, final, {morphStyle:'outerHTML'});
-        initial.value.should.equal('bar');
-    });
-
-    it('specially considers textarea value property in beforeAttributeUpdated hook because value property is special and doesnt reflect', function()
-    {
-        let initial = make('<div><textarea>foo</textarea></div>');
-        let final = make('<textarea>foo</textarea>');
-        final.value = "bar";
-        Idiomorph.morph(initial, final, {morphStyle:'innerHTML',callbacks:{
-            beforeAttributeUpdated: (attr, to, updatetype) => false,
-        }});
-        initial.innerHTML.should.equal('<textarea>foo</textarea>');
-    });
-
-    it('can morph input checked properly, remove checked', function()
-    {
-        let parent = make('<div><input type="checkbox" checked></div>');
-        document.body.append(parent);
-        let initial = parent.querySelector("input");
-
-        let finalSrc = '<input type="checkbox">';
-        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal('<input type="checkbox">');
-        initial.checked.should.equal(false);
-        document.body.removeChild(parent);
-    });
-
-    it('can morph input checked properly, add checked', function()
-    {
-        let parent = make('<div><input type="checkbox"></div>');
-        document.body.append(parent);
-        let initial = parent.querySelector("input");
-
-        let finalSrc = '<input type="checkbox" checked>';
-        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal('<input type="checkbox" checked="">');
-        initial.checked.should.equal(true);
-        document.body.removeChild(parent);
-    });
-
-    it('can morph input checked properly, set checked property to true', function()
-    {
-        let parent = make('<div><input type="checkbox" checked></div>');
-        document.body.append(parent);
-        let initial = parent.querySelector("input");
-        initial.checked = false;
-
-        let finalSrc = '<input type="checkbox" checked>';
-        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal('<input type="checkbox" checked="true">');
-        initial.checked.should.equal(true);
-        document.body.removeChild(parent);
-    });
-
-    it('can morph input checked properly, set checked property to false', function()
-    {
-        let parent = make('<div><input type="checkbox"></div>');
-        document.body.append(parent);
-        let initial = parent.querySelector("input");
-        initial.checked = true;
-
-        let finalSrc = '<input type="checkbox">';
-        Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
-        initial.outerHTML.should.equal('<input type="checkbox">');
-        initial.checked.should.equal(false);
-        document.body.removeChild(parent);
-    });
-
-    it('can override defaults w/ global set', function()
-    {
-        try {
-            // set default to inner HTML
-            Idiomorph.defaults.morphStyle = 'innerHTML';
-            let initial = make("<button>Foo</button>");
-            let finalSrc = "<button>Bar</button>";
-
-            // should more inner HTML despite no config
-            Idiomorph.morph(initial, finalSrc);
-
-            initial.outerHTML.should.equal("<button><button>Bar</button></button>");
-        } finally {
-            Idiomorph.defaults.morphStyle = 'outerHTML';
-        }
-    });
-
-    it('can override globally set default w/ local value', function()
-    {
-        try {
-            // set default to inner HTML
-            Idiomorph.defaults.morphStyle = 'innerHTML';
-            let initial = make("<button>Foo</button>");
-            let finalSrc = "<button>Bar</button>";
-
-            // should morph outer HTML despite default setting
-            Idiomorph.morph(initial, finalSrc, {morphStyle:'outerHTML'});
-
-            initial.outerHTML.should.equal("<button>Bar</button>");
-        } finally {
-            Idiomorph.defaults.morphStyle = 'outerHTML';
-        }
-    });
-
-})
+    initial.innerHTML.should.equal("<textarea>foo</textarea>");
+  });
+
+  it("can morph input checked properly, remove checked", function () {
+    let parent = make('<div><input type="checkbox" checked></div>');
+    document.body.append(parent);
+    let initial = parent.querySelector("input");
+
+    let finalSrc = '<input type="checkbox">';
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal('<input type="checkbox">');
+    initial.checked.should.equal(false);
+    document.body.removeChild(parent);
+  });
+
+  it("can morph input checked properly, add checked", function () {
+    let parent = make('<div><input type="checkbox"></div>');
+    document.body.append(parent);
+    let initial = parent.querySelector("input");
+
+    let finalSrc = '<input type="checkbox" checked>';
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal('<input type="checkbox" checked="">');
+    initial.checked.should.equal(true);
+    document.body.removeChild(parent);
+  });
+
+  it("can morph input checked properly, set checked property to true", function () {
+    let parent = make('<div><input type="checkbox" checked></div>');
+    document.body.append(parent);
+    let initial = parent.querySelector("input");
+    initial.checked = false;
+
+    let finalSrc = '<input type="checkbox" checked>';
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal('<input type="checkbox" checked="true">');
+    initial.checked.should.equal(true);
+    document.body.removeChild(parent);
+  });
+
+  it("can morph input checked properly, set checked property to false", function () {
+    let parent = make('<div><input type="checkbox"></div>');
+    document.body.append(parent);
+    let initial = parent.querySelector("input");
+    initial.checked = true;
+
+    let finalSrc = '<input type="checkbox">';
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal('<input type="checkbox">');
+    initial.checked.should.equal(false);
+    document.body.removeChild(parent);
+  });
+
+  it("can override defaults w/ global set", function () {
+    try {
+      // set default to inner HTML
+      Idiomorph.defaults.morphStyle = "innerHTML";
+      let initial = make("<button>Foo</button>");
+      let finalSrc = "<button>Bar</button>";
+
+      // should more inner HTML despite no config
+      Idiomorph.morph(initial, finalSrc);
+
+      initial.outerHTML.should.equal("<button><button>Bar</button></button>");
+    } finally {
+      Idiomorph.defaults.morphStyle = "outerHTML";
+    }
+  });
+
+  it("can override globally set default w/ local value", function () {
+    try {
+      // set default to inner HTML
+      Idiomorph.defaults.morphStyle = "innerHTML";
+      let initial = make("<button>Foo</button>");
+      let finalSrc = "<button>Bar</button>";
+
+      // should morph outer HTML despite default setting
+      Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+
+      initial.outerHTML.should.equal("<button>Bar</button>");
+    } finally {
+      Idiomorph.defaults.morphStyle = "outerHTML";
+    }
+  });
+});

--- a/test/fidelity.js
+++ b/test/fidelity.js
@@ -1,132 +1,132 @@
-describe("Tests to ensure that idiomorph merges properly", function(){
-    setup();
+describe("Tests to ensure that idiomorph merges properly", function () {
+  setup();
 
-    function expectFidelity(actual, expected) {
-        if (actual.outerHTML !== expected) {
-            console.log("HTML after morph: " + actual.outerHTML);
-            console.log("Expected:         " + expected);
+  function expectFidelity(actual, expected) {
+    if (actual.outerHTML !== expected) {
+      console.log("HTML after morph: " + actual.outerHTML);
+      console.log("Expected:         " + expected);
+    }
+    actual.outerHTML.should.equal(expected);
+  }
+
+  function testFidelity(start, end) {
+    let initial = make(start);
+    let final = make(end);
+    Idiomorph.morph(initial, final);
+
+    expectFidelity(initial, end);
+  }
+
+  // bootstrap test
+  it("morphs text correctly", function () {
+    testFidelity("<button>Foo</button>", "<button>Bar</button>");
+  });
+
+  it("morphs attributes correctly", function () {
+    testFidelity(
+      '<button class="foo">Foo</button>',
+      '<button class="bar">Foo</button>',
+    );
+  });
+
+  it("morphs multiple attributes correctly twice", function () {
+    const a = `<section class="child">A</section>`;
+    const b = `<section class="thing" data-one="1" data-two="2" data-three="3" data-four="4" fizz="buzz" foo="bar">B</section>`;
+    const expectedA = make(a);
+    const expectedB = make(b);
+    const initial = make(a);
+
+    Idiomorph.morph(initial, expectedB);
+    expectFidelity(initial, b);
+
+    Idiomorph.morph(initial, expectedA);
+    expectFidelity(initial, a);
+  });
+
+  it("morphs children", function () {
+    testFidelity("<div><p>A</p><p>B</p></div>", "<div><p>C</p><p>D</p></div>");
+  });
+
+  it("morphs white space", function () {
+    testFidelity(
+      "<div><p>A</p><p>B</p></div>",
+      "<div><p>C</p><p>D</p>  </div>",
+    );
+  });
+
+  it("drops content", function () {
+    testFidelity("<div><p>A</p><p>B</p></div>", "<div></div>");
+  });
+
+  it("adds content", function () {
+    testFidelity("<div></div>", "<div><p>A</p><p>B</p></div>");
+  });
+
+  it("should morph a node", function () {
+    testFidelity("<p>hello world</p>", "<p>hello you</p>");
+  });
+
+  it("should stay same if same", function () {
+    testFidelity("<p>hello world</p>", "<p>hello world</p>");
+  });
+
+  it("should replace a node", function () {
+    testFidelity(
+      "<main><p>hello world</p></main>",
+      "<main><div>hello you</div></main>",
+    );
+  });
+
+  it("should append a node", function () {
+    testFidelity("<main></main>", "<main><p>hello you</p></main>");
+  });
+
+  it("issue https://github.com/bigskysoftware/idiomorph/issues/11", function () {
+    let el1 = make('<fieldset id="el"></fieldset>');
+
+    el1.classList.add("foo");
+    el1.disabled = true;
+
+    // Also fails (reorder setting class and disabling)
+    // el1.disabled = true;
+    // el1.classList.add('foo');
+
+    // Also fails (add and remove class)
+    // el1.classList.add('foo');
+    // el1.classList.remove('foo');
+    // el1.disabled = true;
+
+    let el2 = make('<fieldset id="el">hello</fieldset>');
+
+    // Act
+    Idiomorph.morph(el1, el2);
+
+    // Assert
+    should.equal("hello", el1.innerHTML);
+    should.equal(0, el1.classList.length);
+    should.equal(false, el1.disabled);
+  });
+
+  it("issue https://github.com/bigskysoftware/idiomorph/issues/41", function () {
+    window.customElements.define(
+      "fake-turbo-frame",
+      class extends HTMLElement {
+        static observedAttributes = ["src"];
+        attributeChangedCallback(name, oldValue, newValue) {
+          if (name === "src" && oldValue && oldValue !== newValue) {
+            this.removeAttribute("complete");
+          }
         }
-        actual.outerHTML.should.equal(expected);
-    }
+      },
+    );
 
-    function testFidelity(start, end) {
-        let initial = make(start);
-        let final = make(end);
-        Idiomorph.morph(initial, final);
+    let element = make(
+      '<fake-turbo-frame id="frame" complete="complete" src="https://example.com"></fake-turbo-frame>',
+    );
+    let finalSrc = '<fake-turbo-frame id="frame"></fake-turbo-frame>';
 
-        expectFidelity(initial, end);
-    }
+    Idiomorph.morph(element, finalSrc);
 
-    // bootstrap test
-    it('morphs text correctly', function()
-    {
-        testFidelity("<button>Foo</button>", "<button>Bar</button>")
-    });
-
-    it('morphs attributes correctly', function()
-    {
-        testFidelity("<button class=\"foo\">Foo</button>", "<button class=\"bar\">Foo</button>")
-    });
-
-    it('morphs multiple attributes correctly twice', function ()
-    {
-        const a = `<section class="child">A</section>`;
-        const b = `<section class="thing" data-one="1" data-two="2" data-three="3" data-four="4" fizz="buzz" foo="bar">B</section>`;
-        const expectedA = make(a);
-        const expectedB = make(b);
-        const initial = make(a);
-
-        Idiomorph.morph(initial, expectedB);
-        expectFidelity(initial, b);
-
-        Idiomorph.morph(initial, expectedA);
-        expectFidelity(initial, a);
-    });
-
-    it('morphs children', function()
-    {
-        testFidelity("<div><p>A</p><p>B</p></div>", "<div><p>C</p><p>D</p></div>")
-    });
-
-    it('morphs white space', function()
-    {
-        testFidelity("<div><p>A</p><p>B</p></div>", "<div><p>C</p><p>D</p>  </div>")
-    });
-
-    it('drops content', function()
-    {
-        testFidelity("<div><p>A</p><p>B</p></div>", "<div></div>")
-    });
-
-    it('adds content', function()
-    {
-        testFidelity("<div></div>", "<div><p>A</p><p>B</p></div>")
-    });
-
-    it('should morph a node', function()
-    {
-        testFidelity("<p>hello world</p>", "<p>hello you</p>")
-    });
-
-    it('should stay same if same', function()
-    {
-        testFidelity("<p>hello world</p>", "<p>hello world</p>")
-    });
-
-    it('should replace a node', function()
-    {
-        testFidelity("<main><p>hello world</p></main>", "<main><div>hello you</div></main>")
-    });
-
-    it('should append a node', function()
-    {
-        testFidelity("<main></main>", "<main><p>hello you</p></main>")
-    });
-
-    it('issue https://github.com/bigskysoftware/idiomorph/issues/11', function()
-    {
-        let el1 = make('<fieldset id="el"></fieldset>');
-
-        el1.classList.add('foo');
-        el1.disabled = true;
-
-        // Also fails (reorder setting class and disabling)
-        // el1.disabled = true;
-        // el1.classList.add('foo');
-
-        // Also fails (add and remove class)
-        // el1.classList.add('foo');
-        // el1.classList.remove('foo');
-        // el1.disabled = true;
-
-        let el2 = make('<fieldset id="el">hello</fieldset>')
-
-        // Act
-        Idiomorph.morph(el1, el2);
-
-        // Assert
-        should.equal('hello', el1.innerHTML);
-        should.equal(0, el1.classList.length);
-        should.equal(false, el1.disabled);
-    });
-
-    it('issue https://github.com/bigskysoftware/idiomorph/issues/41', function()
-    {
-        window.customElements.define('fake-turbo-frame', class extends HTMLElement {
-            static observedAttributes = ['src'];
-            attributeChangedCallback(name, oldValue, newValue) {
-                if (name === 'src' && oldValue && oldValue !== newValue) {
-                    this.removeAttribute('complete');
-                }
-            }
-        });
-
-        let element = make('<fake-turbo-frame id="frame" complete="complete" src="https://example.com"></fake-turbo-frame>');
-        let finalSrc = '<fake-turbo-frame id="frame"></fake-turbo-frame>';
-
-        Idiomorph.morph(element, finalSrc);
-
-        element.outerHTML.should.equal(finalSrc);
-    });
-
-})
+    element.outerHTML.should.equal(finalSrc);
+  });
+});

--- a/test/head.js
+++ b/test/head.js
@@ -1,125 +1,205 @@
-describe("Tests to ensure that the head tag merging works correctly", function() {
-    setup();
+describe("Tests to ensure that the head tag merging works correctly", function () {
+  setup();
 
-    it('adds a new element correctly', function () {
-        let parser = new DOMParser();
-        let document = parser.parseFromString("<html><head><title>Foo</title></head></html>", "text/html");
-        let originalHead = document.head;
-        Idiomorph.morph(document, "<html><head><title>Foo</title><meta name='foo' content='bar'></head></html>");
+  it("adds a new element correctly", function () {
+    let parser = new DOMParser();
+    let document = parser.parseFromString(
+      "<html><head><title>Foo</title></head></html>",
+      "text/html",
+    );
+    let originalHead = document.head;
+    Idiomorph.morph(
+      document,
+      "<html><head><title>Foo</title><meta name='foo' content='bar'></head></html>",
+    );
 
-        originalHead.should.equal(document.head);
-        originalHead.childNodes.length.should.equal(2);
-        originalHead.childNodes[0].outerHTML.should.equal("<title>Foo</title>");
-        originalHead.childNodes[1].outerHTML.should.equal("<meta name=\"foo\" content=\"bar\">");
-    });
+    originalHead.should.equal(document.head);
+    originalHead.childNodes.length.should.equal(2);
+    originalHead.childNodes[0].outerHTML.should.equal("<title>Foo</title>");
+    originalHead.childNodes[1].outerHTML.should.equal(
+      '<meta name="foo" content="bar">',
+    );
+  });
 
-    it('removes a new element correctly', function () {
-        let parser = new DOMParser();
-        let document = parser.parseFromString("<html><head><title>Foo</title><meta name='foo' content='bar'></head></html>", "text/html");
-        let originalHead = document.head;
-        Idiomorph.morph(document, "<html><head><title>Foo</title></head></html>");
-        originalHead.should.equal(document.head);
-        originalHead.childNodes.length.should.equal(1);
-        originalHead.childNodes[0].outerHTML.should.equal("<title>Foo</title>");
-    });
+  it("removes a new element correctly", function () {
+    let parser = new DOMParser();
+    let document = parser.parseFromString(
+      "<html><head><title>Foo</title><meta name='foo' content='bar'></head></html>",
+      "text/html",
+    );
+    let originalHead = document.head;
+    Idiomorph.morph(document, "<html><head><title>Foo</title></head></html>");
+    originalHead.should.equal(document.head);
+    originalHead.childNodes.length.should.equal(1);
+    originalHead.childNodes[0].outerHTML.should.equal("<title>Foo</title>");
+  });
 
-    it('preserves an element correctly', function () {
-        let parser = new DOMParser();
-        let document = parser.parseFromString("<html><head><title>Foo</title></head></html>", "text/html");
-        let originalHead = document.head;
-        Idiomorph.morph(document, "<html><head><title>Foo</title></head></html>");
+  it("preserves an element correctly", function () {
+    let parser = new DOMParser();
+    let document = parser.parseFromString(
+      "<html><head><title>Foo</title></head></html>",
+      "text/html",
+    );
+    let originalHead = document.head;
+    Idiomorph.morph(document, "<html><head><title>Foo</title></head></html>");
 
-        originalHead.should.equal(document.head);
-        originalHead.childNodes.length.should.equal(1);
-        originalHead.childNodes[0].outerHTML.should.equal("<title>Foo</title>");
-    });
+    originalHead.should.equal(document.head);
+    originalHead.childNodes.length.should.equal(1);
+    originalHead.childNodes[0].outerHTML.should.equal("<title>Foo</title>");
+  });
 
-    it('head elements are preserved in order', function () {
-        let parser = new DOMParser();
-        let document = parser.parseFromString("<html><head><title>Foo</title><meta name='foo' content='bar'></head></html>", "text/html");
-        let originalHead = document.head;
-        Idiomorph.morph(document, "<html><head><meta name='foo' content='bar'><title>Foo</title></head></html>");
+  it("head elements are preserved in order", function () {
+    let parser = new DOMParser();
+    let document = parser.parseFromString(
+      "<html><head><title>Foo</title><meta name='foo' content='bar'></head></html>",
+      "text/html",
+    );
+    let originalHead = document.head;
+    Idiomorph.morph(
+      document,
+      "<html><head><meta name='foo' content='bar'><title>Foo</title></head></html>",
+    );
 
-        originalHead.should.equal(document.head);
-        originalHead.childNodes.length.should.equal(2);
-        originalHead.childNodes[0].outerHTML.should.equal("<title>Foo</title>");
-        originalHead.childNodes[1].outerHTML.should.equal("<meta name=\"foo\" content=\"bar\">");
-    });
+    originalHead.should.equal(document.head);
+    originalHead.childNodes.length.should.equal(2);
+    originalHead.childNodes[0].outerHTML.should.equal("<title>Foo</title>");
+    originalHead.childNodes[1].outerHTML.should.equal(
+      '<meta name="foo" content="bar">',
+    );
+  });
 
-    it('morph style reorders head', function () {
-        let parser = new DOMParser();
-        let document = parser.parseFromString("<html><head><title>Foo</title><meta name='foo' content='bar'></head></html>", "text/html");
-        let originalHead = document.head;
-        Idiomorph.morph(document, "<html><head><meta name='foo' content='bar'><title>Foo</title></head></html>", {head:{style:'morph'}});
+  it("morph style reorders head", function () {
+    let parser = new DOMParser();
+    let document = parser.parseFromString(
+      "<html><head><title>Foo</title><meta name='foo' content='bar'></head></html>",
+      "text/html",
+    );
+    let originalHead = document.head;
+    Idiomorph.morph(
+      document,
+      "<html><head><meta name='foo' content='bar'><title>Foo</title></head></html>",
+      { head: { style: "morph" } },
+    );
 
-        originalHead.should.equal(document.head);
-        originalHead.childNodes.length.should.equal(2);
-        originalHead.childNodes[0].outerHTML.should.equal("<meta name=\"foo\" content=\"bar\">");
-        originalHead.childNodes[1].outerHTML.should.equal("<title>Foo</title>");
-    });
+    originalHead.should.equal(document.head);
+    originalHead.childNodes.length.should.equal(2);
+    originalHead.childNodes[0].outerHTML.should.equal(
+      '<meta name="foo" content="bar">',
+    );
+    originalHead.childNodes[1].outerHTML.should.equal("<title>Foo</title>");
+  });
 
-    it('append style appends to head', function () {
-        let parser = new DOMParser();
-        let document = parser.parseFromString("<html><head><title>Foo</title></head></html>", "text/html");
-        let originalHead = document.head;
-        Idiomorph.morph(document, "<html><head><meta name='foo' content='bar'></head></html>", {head:{style:'append'}});
+  it("append style appends to head", function () {
+    let parser = new DOMParser();
+    let document = parser.parseFromString(
+      "<html><head><title>Foo</title></head></html>",
+      "text/html",
+    );
+    let originalHead = document.head;
+    Idiomorph.morph(
+      document,
+      "<html><head><meta name='foo' content='bar'></head></html>",
+      { head: { style: "append" } },
+    );
 
-        originalHead.should.equal(document.head);
-        originalHead.childNodes.length.should.equal(2);
-        originalHead.childNodes[0].outerHTML.should.equal("<title>Foo</title>");
-        originalHead.childNodes[1].outerHTML.should.equal("<meta name=\"foo\" content=\"bar\">");
-    });
+    originalHead.should.equal(document.head);
+    originalHead.childNodes.length.should.equal(2);
+    originalHead.childNodes[0].outerHTML.should.equal("<title>Foo</title>");
+    originalHead.childNodes[1].outerHTML.should.equal(
+      '<meta name="foo" content="bar">',
+    );
+  });
 
-    it('ignore style ignores head', function () {
-        let parser = new DOMParser();
-        let document = parser.parseFromString("<html><head><title>Foo</title></head></html>", "text/html");
-        let originalHead = document.head;
-        Idiomorph.morph(document, "<html><head><meta name='foo' content='bar'></head></html>", {head:{ignore:true}});
+  it("ignore style ignores head", function () {
+    let parser = new DOMParser();
+    let document = parser.parseFromString(
+      "<html><head><title>Foo</title></head></html>",
+      "text/html",
+    );
+    let originalHead = document.head;
+    Idiomorph.morph(
+      document,
+      "<html><head><meta name='foo' content='bar'></head></html>",
+      { head: { ignore: true } },
+    );
 
-        originalHead.outerHTML.should.equal("<head><title>Foo</title></head>");
-    });
+    originalHead.outerHTML.should.equal("<head><title>Foo</title></head>");
+  });
 
-    it('im-preserve preserves', function () {
-        let parser = new DOMParser();
-        let document = parser.parseFromString("<html><head><title im-preserve='true'>Foo</title></head></html>", "text/html");
-        let originalHead = document.head;
-        Idiomorph.morph(document, "<html><head><meta name='foo' content='bar'></head></html>");
+  it("im-preserve preserves", function () {
+    let parser = new DOMParser();
+    let document = parser.parseFromString(
+      "<html><head><title im-preserve='true'>Foo</title></head></html>",
+      "text/html",
+    );
+    let originalHead = document.head;
+    Idiomorph.morph(
+      document,
+      "<html><head><meta name='foo' content='bar'></head></html>",
+    );
 
-        originalHead.should.equal(document.head);
-        originalHead.childNodes.length.should.equal(2);
-        originalHead.childNodes[0].outerHTML.should.equal("<title im-preserve=\"true\">Foo</title>");
-        originalHead.childNodes[1].outerHTML.should.equal("<meta name=\"foo\" content=\"bar\">");
-    });
+    originalHead.should.equal(document.head);
+    originalHead.childNodes.length.should.equal(2);
+    originalHead.childNodes[0].outerHTML.should.equal(
+      '<title im-preserve="true">Foo</title>',
+    );
+    originalHead.childNodes[1].outerHTML.should.equal(
+      '<meta name="foo" content="bar">',
+    );
+  });
 
-    it('im-re-append re-appends', function () {
-        let parser = new DOMParser();
-        let document = parser.parseFromString("<html><head><title im-re-append='true'>Foo</title></head></html>", "text/html");
-        let originalHead = document.head;
-        let originalTitle = originalHead.children[0];
-        Idiomorph.morph(document, "<html><head><title im-re-append='true'>Foo</title><meta name='foo' content='bar'></head></html>");
+  it("im-re-append re-appends", function () {
+    let parser = new DOMParser();
+    let document = parser.parseFromString(
+      "<html><head><title im-re-append='true'>Foo</title></head></html>",
+      "text/html",
+    );
+    let originalHead = document.head;
+    let originalTitle = originalHead.children[0];
+    Idiomorph.morph(
+      document,
+      "<html><head><title im-re-append='true'>Foo</title><meta name='foo' content='bar'></head></html>",
+    );
 
-        originalHead.should.equal(document.head);
-        originalHead.childNodes.length.should.equal(2);
-        originalHead.childNodes[0].outerHTML.should.equal("<title im-re-append=\"true\">Foo</title>");
-        originalHead.childNodes[0].should.not.equal(originalTitle); // original title should have been removed in place of a new, reappended title
-        originalHead.childNodes[1].outerHTML.should.equal("<meta name=\"foo\" content=\"bar\">");
-    });
+    originalHead.should.equal(document.head);
+    originalHead.childNodes.length.should.equal(2);
+    originalHead.childNodes[0].outerHTML.should.equal(
+      '<title im-re-append="true">Foo</title>',
+    );
+    originalHead.childNodes[0].should.not.equal(originalTitle); // original title should have been removed in place of a new, reappended title
+    originalHead.childNodes[1].outerHTML.should.equal(
+      '<meta name="foo" content="bar">',
+    );
+  });
 
-    it('im-re-append re-appends with append style', function () {
-        let parser = new DOMParser();
-        let document = parser.parseFromString("<html><head><meta name='foo' content='bar' im-re-append='true'></head></html>", "text/html");
-        let originalHead = document.head;
-        let originalTitle = originalHead.children[0];
-        Idiomorph.morph(document, "<html><head><meta name='bar' content='baz' im-re-append='true'></head></html>", {head:{style:'append'}});
+  it("im-re-append re-appends with append style", function () {
+    let parser = new DOMParser();
+    let document = parser.parseFromString(
+      "<html><head><meta name='foo' content='bar' im-re-append='true'></head></html>",
+      "text/html",
+    );
+    let originalHead = document.head;
+    let originalTitle = originalHead.children[0];
+    Idiomorph.morph(
+      document,
+      "<html><head><meta name='bar' content='baz' im-re-append='true'></head></html>",
+      { head: { style: "append" } },
+    );
 
-        originalHead.should.equal(document.head);
-        originalHead.childNodes.length.should.equal(2);
-        originalHead.innerHTML.should.equal('<meta name="foo" content="bar" im-re-append="true"><meta name="bar" content="baz" im-re-append="true">');
-    });
+    originalHead.should.equal(document.head);
+    originalHead.childNodes.length.should.equal(2);
+    originalHead.innerHTML.should.equal(
+      '<meta name="foo" content="bar" im-re-append="true"><meta name="bar" content="baz" im-re-append="true">',
+    );
+  });
 
-    it('can handle scripts with block mode', async function(){
-        Idiomorph.morph(window.document, `<head><script src='/test/lib/fixture.js'></script></head>`,{head:{block:true,style:'append'}});
-        await waitFor(() => window.hasOwnProperty("fixture"))
-        window.fixture.should.equal("FIXTURE")
-    });
+  it("can handle scripts with block mode", async function () {
+    Idiomorph.morph(
+      window.document,
+      `<head><script src='/test/lib/fixture.js'></script></head>`,
+      { head: { block: true, style: "append" } },
+    );
+    await waitFor(() => window.hasOwnProperty("fixture"));
+    window.fixture.should.equal("FIXTURE");
+  });
 });

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,178 +1,209 @@
-describe("lifecycle hooks", function(){
-    beforeEach(function() {
-        clearWorkArea();
-    });
+describe("lifecycle hooks", function () {
+  beforeEach(function () {
+    clearWorkArea();
+  });
 
-    it('calls beforeNodeAdded before a new node is added to the DOM', function(){
-        let calls = [];
-        let initial = make("<ul><li>A</li></ul>");
-        Idiomorph.morph(initial, "<ul><li>A</li><li>B</li></ul>", { callbacks: {
-            beforeNodeAdded: node => {
-                calls.push(node.outerHTML);
-            }
-        } });
-        initial.outerHTML.should.equal("<ul><li>A</li><li>B</li></ul>");
-        calls.should.eql(["<li>B</li>"]);
+  it("calls beforeNodeAdded before a new node is added to the DOM", function () {
+    let calls = [];
+    let initial = make("<ul><li>A</li></ul>");
+    Idiomorph.morph(initial, "<ul><li>A</li><li>B</li></ul>", {
+      callbacks: {
+        beforeNodeAdded: (node) => {
+          calls.push(node.outerHTML);
+        },
+      },
     });
+    initial.outerHTML.should.equal("<ul><li>A</li><li>B</li></ul>");
+    calls.should.eql(["<li>B</li>"]);
+  });
 
-    it('returning false to beforeNodeAdded prevents adding the node', function(){
-        let initial = make("<ul><li>A</li></ul>");
-        Idiomorph.morph(initial, "<ul><li>A</li><li>B</li></ul>", { callbacks: {
-            beforeNodeAdded: node => false,
-        } });
-        initial.outerHTML.should.equal("<ul><li>A</li></ul>");
+  it("returning false to beforeNodeAdded prevents adding the node", function () {
+    let initial = make("<ul><li>A</li></ul>");
+    Idiomorph.morph(initial, "<ul><li>A</li><li>B</li></ul>", {
+      callbacks: {
+        beforeNodeAdded: (node) => false,
+      },
     });
+    initial.outerHTML.should.equal("<ul><li>A</li></ul>");
+  });
 
-    it('calls afterNodeAdded after a new node is added to the DOM', function(){
-        let calls = [];
-        let initial = make("<ul><li>A</li></ul>");
-        Idiomorph.morph(initial, "<ul><li>A</li><li>B</li></ul>", { callbacks: {
-            afterNodeAdded: node => {
-                calls.push(node.outerHTML);
-            }
-        } });
-        initial.outerHTML.should.equal("<ul><li>A</li><li>B</li></ul>");
-        calls.should.eql(["<li>B</li>"]);
+  it("calls afterNodeAdded after a new node is added to the DOM", function () {
+    let calls = [];
+    let initial = make("<ul><li>A</li></ul>");
+    Idiomorph.morph(initial, "<ul><li>A</li><li>B</li></ul>", {
+      callbacks: {
+        afterNodeAdded: (node) => {
+          calls.push(node.outerHTML);
+        },
+      },
     });
+    initial.outerHTML.should.equal("<ul><li>A</li><li>B</li></ul>");
+    calls.should.eql(["<li>B</li>"]);
+  });
 
-    it('calls beforeNodeMorphed before a node is morphed', function(){
-        let calls = [];
-        let initial = make(`<ul><li id="a">A</li></ul>`);
-        Idiomorph.morph(initial, `<ul><li id="a">B</li></ul>`, { callbacks: {
-            beforeNodeMorphed: (oldNode, newNode) => {
-                calls.push([
-                  oldNode.outerHTML || oldNode.textContent,
-                  newNode.outerHTML || newNode.textContent,
-                ]);
-            }
-        } });
-        initial.outerHTML.should.equal(`<ul><li id="a">B</li></ul>`);
-        calls.should.eql([
-          [`<ul><li id="a">A</li></ul>`, `<ul><li id="a">B</li></ul>`],
-          [`<li id="a">A</li>`, `<li id="a">B</li>`],
-          [`A`, `B`],
-        ]);
+  it("calls beforeNodeMorphed before a node is morphed", function () {
+    let calls = [];
+    let initial = make(`<ul><li id="a">A</li></ul>`);
+    Idiomorph.morph(initial, `<ul><li id="a">B</li></ul>`, {
+      callbacks: {
+        beforeNodeMorphed: (oldNode, newNode) => {
+          calls.push([
+            oldNode.outerHTML || oldNode.textContent,
+            newNode.outerHTML || newNode.textContent,
+          ]);
+        },
+      },
     });
+    initial.outerHTML.should.equal(`<ul><li id="a">B</li></ul>`);
+    calls.should.eql([
+      [`<ul><li id="a">A</li></ul>`, `<ul><li id="a">B</li></ul>`],
+      [`<li id="a">A</li>`, `<li id="a">B</li>`],
+      [`A`, `B`],
+    ]);
+  });
 
-    it('returning false to beforeNodeMorphed prevents morphing the node', function(){
-        let initial = make(`<ul name="a"><li name="a" id="a">A</li></ul>`);
-        Idiomorph.morph(initial, `<ul name="b"><li name="b" id="a">B</li></ul>`, { callbacks: {
-            beforeNodeMorphed: node => {
-              if(node.nodeType === Node.TEXT_NODE) return false
-            }
-        } })
-        initial.outerHTML.should.equal(`<ul name="b"><li name="b" id="a">A</li></ul>`);
+  it("returning false to beforeNodeMorphed prevents morphing the node", function () {
+    let initial = make(`<ul name="a"><li name="a" id="a">A</li></ul>`);
+    Idiomorph.morph(initial, `<ul name="b"><li name="b" id="a">B</li></ul>`, {
+      callbacks: {
+        beforeNodeMorphed: (node) => {
+          if (node.nodeType === Node.TEXT_NODE) return false;
+        },
+      },
     });
+    initial.outerHTML.should.equal(
+      `<ul name="b"><li name="b" id="a">A</li></ul>`,
+    );
+  });
 
-    it('calls afterNodeMorphed before a node is morphed', function(){
-        let calls = [];
-        let initial = make(`<ul><li id="a">A</li></ul>`);
-        Idiomorph.morph(initial, `<ul><li id="a">B</li></ul>`, { callbacks: {
-            afterNodeMorphed: (oldNode, newNode) => {
-                calls.push([
-                  oldNode.outerHTML || oldNode.textContent,
-                  newNode.outerHTML || newNode.textContent,
-                ]);
-            }
-        } });
-        initial.outerHTML.should.equal(`<ul><li id="a">B</li></ul>`);
-        calls.should.eql([
-          [`B`, `B`],
-          [`<li id="a">B</li>`, `<li id="a">B</li>`],
-          [`<ul><li id="a">B</li></ul>`, `<ul><li id="a">B</li></ul>`],
-        ]);
+  it("calls afterNodeMorphed before a node is morphed", function () {
+    let calls = [];
+    let initial = make(`<ul><li id="a">A</li></ul>`);
+    Idiomorph.morph(initial, `<ul><li id="a">B</li></ul>`, {
+      callbacks: {
+        afterNodeMorphed: (oldNode, newNode) => {
+          calls.push([
+            oldNode.outerHTML || oldNode.textContent,
+            newNode.outerHTML || newNode.textContent,
+          ]);
+        },
+      },
     });
+    initial.outerHTML.should.equal(`<ul><li id="a">B</li></ul>`);
+    calls.should.eql([
+      [`B`, `B`],
+      [`<li id="a">B</li>`, `<li id="a">B</li>`],
+      [`<ul><li id="a">B</li></ul>`, `<ul><li id="a">B</li></ul>`],
+    ]);
+  });
 
-    it('calls beforeNodeRemoved before a node is removed from the DOM', function(){
-        let calls = [];
-        let initial = make("<ul><li>A</li><li>B</li></ul>");
-        Idiomorph.morph(initial, "<ul><li>A</li></ul>", { callbacks: {
-            beforeNodeRemoved: node => {
-                calls.push(node.outerHTML);
-            }
-        } });
-        initial.outerHTML.should.equal("<ul><li>A</li></ul>");
-        calls.should.eql(["<li>B</li>"]);
+  it("calls beforeNodeRemoved before a node is removed from the DOM", function () {
+    let calls = [];
+    let initial = make("<ul><li>A</li><li>B</li></ul>");
+    Idiomorph.morph(initial, "<ul><li>A</li></ul>", {
+      callbacks: {
+        beforeNodeRemoved: (node) => {
+          calls.push(node.outerHTML);
+        },
+      },
     });
+    initial.outerHTML.should.equal("<ul><li>A</li></ul>");
+    calls.should.eql(["<li>B</li>"]);
+  });
 
-    it('returning false to beforeNodeRemoved prevents removing the node', function(){
-        let initial = make("<ul><li>A</li><li>B</li></ul>");
-        Idiomorph.morph(initial, "<ul><li>A</li></ul>", { callbacks: {
-            beforeNodeRemoved: node => false,
-        } });
-        initial.outerHTML.should.equal("<ul><li>A</li><li>B</li></ul>");
+  it("returning false to beforeNodeRemoved prevents removing the node", function () {
+    let initial = make("<ul><li>A</li><li>B</li></ul>");
+    Idiomorph.morph(initial, "<ul><li>A</li></ul>", {
+      callbacks: {
+        beforeNodeRemoved: (node) => false,
+      },
     });
+    initial.outerHTML.should.equal("<ul><li>A</li><li>B</li></ul>");
+  });
 
-    it('calls afterNodeRemoved after a node is removed from the DOM', function(){
-        let calls = [];
-        let initial = make("<ul><li>A</li><li>B</li></ul>");
-        Idiomorph.morph(initial, "<ul><li>A</li></ul>", { callbacks: {
-            afterNodeRemoved: node => {
-                calls.push(node.outerHTML);
-            }
-        } });
-        initial.outerHTML.should.equal("<ul><li>A</li></ul>");
-        calls.should.eql(["<li>B</li>"]);
+  it("calls afterNodeRemoved after a node is removed from the DOM", function () {
+    let calls = [];
+    let initial = make("<ul><li>A</li><li>B</li></ul>");
+    Idiomorph.morph(initial, "<ul><li>A</li></ul>", {
+      callbacks: {
+        afterNodeRemoved: (node) => {
+          calls.push(node.outerHTML);
+        },
+      },
     });
+    initial.outerHTML.should.equal("<ul><li>A</li></ul>");
+    calls.should.eql(["<li>B</li>"]);
+  });
 
-    it('calls beforeAttributeUpdated when an attribute is added', function(){
-        let calls = [];
-        let initial = make("<a></a>");
-        Idiomorph.morph(initial, `<a href="#"></a>`, { callbacks: {
-            beforeAttributeUpdated: (attributeName, node, mutationType) => {
-                calls.push([attributeName, node.outerHTML, mutationType]);
-            }
-        } });
-        initial.outerHTML.should.equal(`<a href="#"></a>`);
-        calls.should.eql([["href", `<a></a>`, "update"]]);
+  it("calls beforeAttributeUpdated when an attribute is added", function () {
+    let calls = [];
+    let initial = make("<a></a>");
+    Idiomorph.morph(initial, `<a href="#"></a>`, {
+      callbacks: {
+        beforeAttributeUpdated: (attributeName, node, mutationType) => {
+          calls.push([attributeName, node.outerHTML, mutationType]);
+        },
+      },
     });
+    initial.outerHTML.should.equal(`<a href="#"></a>`);
+    calls.should.eql([["href", `<a></a>`, "update"]]);
+  });
 
-    it('calls beforeAttributeUpdated when an attribute is updated', function(){
-        let calls = [];
-        let initial = make(`<a href="a"></a>`);
-        Idiomorph.morph(initial, `<a href="b"></a>`, { callbacks: {
-            beforeAttributeUpdated: (attributeName, node, mutationType) => {
-                calls.push([attributeName, node.outerHTML, mutationType]);
-            }
-        } });
-        initial.outerHTML.should.equal(`<a href="b"></a>`);
-        calls.should.eql([["href", `<a href="a"></a>`, "update"]]);
+  it("calls beforeAttributeUpdated when an attribute is updated", function () {
+    let calls = [];
+    let initial = make(`<a href="a"></a>`);
+    Idiomorph.morph(initial, `<a href="b"></a>`, {
+      callbacks: {
+        beforeAttributeUpdated: (attributeName, node, mutationType) => {
+          calls.push([attributeName, node.outerHTML, mutationType]);
+        },
+      },
     });
+    initial.outerHTML.should.equal(`<a href="b"></a>`);
+    calls.should.eql([["href", `<a href="a"></a>`, "update"]]);
+  });
 
-    it('calls beforeAttributeUpdated when an attribute is removed', function(){
-        let calls = [];
-        let initial = make(`<a href="#"></a>`);
-        Idiomorph.morph(initial, `<a></a>`, { callbacks: {
-            beforeAttributeUpdated: (attributeName, node, mutationType) => {
-                calls.push([attributeName, node.outerHTML, mutationType]);
-            }
-        } });
-        initial.outerHTML.should.equal(`<a></a>`);
-        calls.should.eql([["href", `<a href="#"></a>`, "remove"]]);
+  it("calls beforeAttributeUpdated when an attribute is removed", function () {
+    let calls = [];
+    let initial = make(`<a href="#"></a>`);
+    Idiomorph.morph(initial, `<a></a>`, {
+      callbacks: {
+        beforeAttributeUpdated: (attributeName, node, mutationType) => {
+          calls.push([attributeName, node.outerHTML, mutationType]);
+        },
+      },
     });
+    initial.outerHTML.should.equal(`<a></a>`);
+    calls.should.eql([["href", `<a href="#"></a>`, "remove"]]);
+  });
 
-    it('returning false to beforeAttributeUpdated prevents the attribute addition', function(){
-        let initial = make("<a></a>");
-        Idiomorph.morph(initial, `<a href="#"></a>`, { callbacks: {
-            beforeAttributeUpdated: () => false,
-        } });
-        initial.outerHTML.should.equal(`<a></a>`);
+  it("returning false to beforeAttributeUpdated prevents the attribute addition", function () {
+    let initial = make("<a></a>");
+    Idiomorph.morph(initial, `<a href="#"></a>`, {
+      callbacks: {
+        beforeAttributeUpdated: () => false,
+      },
     });
+    initial.outerHTML.should.equal(`<a></a>`);
+  });
 
-    it('returning false to beforeAttributeUpdated prevents the attribute update', function(){
-        let initial = make(`<a href="a"></a>`);
-        Idiomorph.morph(initial, `<a href="b"></a>`, { callbacks: {
-            beforeAttributeUpdated: () => false,
-        } });
-        initial.outerHTML.should.equal(`<a href="a"></a>`);
+  it("returning false to beforeAttributeUpdated prevents the attribute update", function () {
+    let initial = make(`<a href="a"></a>`);
+    Idiomorph.morph(initial, `<a href="b"></a>`, {
+      callbacks: {
+        beforeAttributeUpdated: () => false,
+      },
     });
+    initial.outerHTML.should.equal(`<a href="a"></a>`);
+  });
 
-    it('returning false to beforeAttributeUpdated prevents the attribute removal', function(){
-        let initial = make(`<a href="#"></a>`);
-        Idiomorph.morph(initial, `<a></a>`, { callbacks: {
-            beforeAttributeUpdated: () => false,
-        } });
-        initial.outerHTML.should.equal(`<a href="#"></a>`);
+  it("returning false to beforeAttributeUpdated prevents the attribute removal", function () {
+    let initial = make(`<a href="#"></a>`);
+    Idiomorph.morph(initial, `<a></a>`, {
+      callbacks: {
+        beforeAttributeUpdated: () => false,
+      },
     });
+    initial.outerHTML.should.equal(`<a href="#"></a>`);
+  });
 });
-

--- a/test/htmx-integration.js
+++ b/test/htmx-integration.js
@@ -1,107 +1,150 @@
-describe("Tests for the htmx integration", function() {
-    function makeServer(){
-        var server = sinon.fakeServer.create();
-        htmx.config.defaultSettleDelay = 0;
-        server.fakeHTTPMethods = true;
-        return server;
-    }
+describe("Tests for the htmx integration", function () {
+  function makeServer() {
+    var server = sinon.fakeServer.create();
+    htmx.config.defaultSettleDelay = 0;
+    server.fakeHTTPMethods = true;
+    return server;
+  }
 
-    beforeEach(function () {
-        this.server = makeServer();
-        clearWorkArea();
-    });
+  beforeEach(function () {
+    this.server = makeServer();
+    clearWorkArea();
+  });
 
-    afterEach(function () {
-        this.server.restore();
-    });
+  afterEach(function () {
+    this.server.restore();
+  });
 
-    function makeForHtmxTest(htmlStr) {
-        let elt = make(htmlStr)
-        getWorkArea().appendChild(elt);
-        htmx.process(elt);
-        return elt;
-    }
+  function makeForHtmxTest(htmlStr) {
+    let elt = make(htmlStr);
+    getWorkArea().appendChild(elt);
+    htmx.process(elt);
+    return elt;
+  }
 
-    it('keeps the element stable in an outer morph', function () {
-        this.server.respondWith("GET", "/test", "<button id='b1' hx-swap='morph' hx-get='/test' class='bar'>Foo</button>");
-        let initialBtn = makeForHtmxTest("<button id='b1' hx-swap='morph' hx-get='/test'>Foo</button>");
-        initialBtn.click();
-        this.server.respond();
-        let newBtn = document.getElementById('b1');
-        initialBtn.should.equal(newBtn);
-        initialBtn.classList.contains('bar').should.equal(true);
-    });
+  it("keeps the element stable in an outer morph", function () {
+    this.server.respondWith(
+      "GET",
+      "/test",
+      "<button id='b1' hx-swap='morph' hx-get='/test' class='bar'>Foo</button>",
+    );
+    let initialBtn = makeForHtmxTest(
+      "<button id='b1' hx-swap='morph' hx-get='/test'>Foo</button>",
+    );
+    initialBtn.click();
+    this.server.respond();
+    let newBtn = document.getElementById("b1");
+    initialBtn.should.equal(newBtn);
+    initialBtn.classList.contains("bar").should.equal(true);
+  });
 
-    it('keeps the element live in an outer morph', function () {
-        this.server.respondWith("GET", "/test", "<button id='b1' hx-swap='morph' hx-get='/test2' class='bar'>Foo</button>");
-        this.server.respondWith("GET", "/test2", "<button id='b1' hx-swap='morph' hx-get='/test3' class='doh'>Foo</button>");
-        let initialBtn = makeForHtmxTest("<button id='b1' hx-swap='morph' hx-get='/test'>Foo</button>");
+  it("keeps the element live in an outer morph", function () {
+    this.server.respondWith(
+      "GET",
+      "/test",
+      "<button id='b1' hx-swap='morph' hx-get='/test2' class='bar'>Foo</button>",
+    );
+    this.server.respondWith(
+      "GET",
+      "/test2",
+      "<button id='b1' hx-swap='morph' hx-get='/test3' class='doh'>Foo</button>",
+    );
+    let initialBtn = makeForHtmxTest(
+      "<button id='b1' hx-swap='morph' hx-get='/test'>Foo</button>",
+    );
 
-        initialBtn.click();
-        this.server.respond();
-        let newBtn = document.getElementById('b1');
-        initialBtn.should.equal(newBtn);
-        initialBtn.classList.contains('bar').should.equal(true);
-        initialBtn.classList.contains('doh').should.equal(false);
+    initialBtn.click();
+    this.server.respond();
+    let newBtn = document.getElementById("b1");
+    initialBtn.should.equal(newBtn);
+    initialBtn.classList.contains("bar").should.equal(true);
+    initialBtn.classList.contains("doh").should.equal(false);
 
-        initialBtn.click();
-        this.server.respond();
-        newBtn = document.getElementById('b1');
-        initialBtn.should.equal(newBtn);
-        initialBtn.classList.contains('bar').should.equal(false);
-        initialBtn.classList.contains('doh').should.equal(true);
-    });
+    initialBtn.click();
+    this.server.respond();
+    newBtn = document.getElementById("b1");
+    initialBtn.should.equal(newBtn);
+    initialBtn.classList.contains("bar").should.equal(false);
+    initialBtn.classList.contains("doh").should.equal(true);
+  });
 
-    it('keeps the element stable in an outer morph w/ explicit syntax', function () {
-        this.server.respondWith("GET", "/test", "<button id='b1' hx-swap='morph:outerHTML' hx-get='/test' class='bar'>Foo</button>");
-        let initialBtn = makeForHtmxTest("<button id='b1' hx-swap='morph:outerHTML' hx-get='/test'>Foo</button>");
-        initialBtn.click();
-        this.server.respond();
-        let newBtn = document.getElementById('b1');
-        initialBtn.should.equal(newBtn);
-        initialBtn.classList.contains('bar').should.equal(true);
-    });
+  it("keeps the element stable in an outer morph w/ explicit syntax", function () {
+    this.server.respondWith(
+      "GET",
+      "/test",
+      "<button id='b1' hx-swap='morph:outerHTML' hx-get='/test' class='bar'>Foo</button>",
+    );
+    let initialBtn = makeForHtmxTest(
+      "<button id='b1' hx-swap='morph:outerHTML' hx-get='/test'>Foo</button>",
+    );
+    initialBtn.click();
+    this.server.respond();
+    let newBtn = document.getElementById("b1");
+    initialBtn.should.equal(newBtn);
+    initialBtn.classList.contains("bar").should.equal(true);
+  });
 
-    it('keeps the element live in an outer morph w/explicit syntax', function () {
-        this.server.respondWith("GET", "/test", "<button id='b1' hx-swap='morph:outerHTML' hx-get='/test2' class='bar'>Foo</button>");
-        this.server.respondWith("GET", "/test2", "<button id='b1' hx-swap='morph:outerHTML' hx-get='/test3' class='doh'>Foo</button>");
-        let initialBtn = makeForHtmxTest("<button id='b1' hx-swap='morph:outerHTML' hx-get='/test'>Foo</button>");
+  it("keeps the element live in an outer morph w/explicit syntax", function () {
+    this.server.respondWith(
+      "GET",
+      "/test",
+      "<button id='b1' hx-swap='morph:outerHTML' hx-get='/test2' class='bar'>Foo</button>",
+    );
+    this.server.respondWith(
+      "GET",
+      "/test2",
+      "<button id='b1' hx-swap='morph:outerHTML' hx-get='/test3' class='doh'>Foo</button>",
+    );
+    let initialBtn = makeForHtmxTest(
+      "<button id='b1' hx-swap='morph:outerHTML' hx-get='/test'>Foo</button>",
+    );
 
-        initialBtn.click();
-        this.server.respond();
-        let newBtn = document.getElementById('b1');
-        initialBtn.should.equal(newBtn);
-        initialBtn.classList.contains('bar').should.equal(true);
-        initialBtn.classList.contains('doh').should.equal(false);
+    initialBtn.click();
+    this.server.respond();
+    let newBtn = document.getElementById("b1");
+    initialBtn.should.equal(newBtn);
+    initialBtn.classList.contains("bar").should.equal(true);
+    initialBtn.classList.contains("doh").should.equal(false);
 
-        initialBtn.click();
-        this.server.respond();
-        newBtn = document.getElementById('b1');
-        initialBtn.should.equal(newBtn);
-        initialBtn.classList.contains('bar').should.equal(false);
-        initialBtn.classList.contains('doh').should.equal(true);
-    });
+    initialBtn.click();
+    this.server.respond();
+    newBtn = document.getElementById("b1");
+    initialBtn.should.equal(newBtn);
+    initialBtn.classList.contains("bar").should.equal(false);
+    initialBtn.classList.contains("doh").should.equal(true);
+  });
 
-    it('keeps elements stable in an inner morph', function () {
-        this.server.respondWith("GET", "/test", "<button id='b1' class='bar'>Foo</button>");
-        let div = makeForHtmxTest("<div hx-swap='morph:innerHTML' hx-get='/test'><button id='b1'>Foo</button></div>");
-        let initialBtn = document.getElementById('b1');
-        div.click();
-        this.server.respond();
-        let newBtn = document.getElementById('b1');
-        initialBtn.should.equal(newBtn);
-        initialBtn.classList.contains('bar').should.equal(true);
-    });
+  it("keeps elements stable in an inner morph", function () {
+    this.server.respondWith(
+      "GET",
+      "/test",
+      "<button id='b1' class='bar'>Foo</button>",
+    );
+    let div = makeForHtmxTest(
+      "<div hx-swap='morph:innerHTML' hx-get='/test'><button id='b1'>Foo</button></div>",
+    );
+    let initialBtn = document.getElementById("b1");
+    div.click();
+    this.server.respond();
+    let newBtn = document.getElementById("b1");
+    initialBtn.should.equal(newBtn);
+    initialBtn.classList.contains("bar").should.equal(true);
+  });
 
-    it('keeps elements stable in an inner morph w/ long syntax', function () {
-        this.server.respondWith("GET", "/test", "<button id='b1' class='bar'>Foo</button>");
-        let div = makeForHtmxTest("<div hx-swap='morph:{morphStyle:\"innerHTML\"}' hx-get='/test'><button id='b1'>Foo</button></div>");
-        let initialBtn = document.getElementById('b1');
-        div.click();
-        this.server.respond();
-        let newBtn = document.getElementById('b1');
-        initialBtn.should.equal(newBtn);
-        initialBtn.classList.contains('bar').should.equal(true);
-    });
-
-})
+  it("keeps elements stable in an inner morph w/ long syntax", function () {
+    this.server.respondWith(
+      "GET",
+      "/test",
+      "<button id='b1' class='bar'>Foo</button>",
+    );
+    let div = makeForHtmxTest(
+      "<div hx-swap='morph:{morphStyle:\"innerHTML\"}' hx-get='/test'><button id='b1'>Foo</button></div>",
+    );
+    let initialBtn = document.getElementById("b1");
+    div.click();
+    this.server.respond();
+    let newBtn = document.getElementById("b1");
+    initialBtn.should.equal(newBtn);
+    initialBtn.classList.contains("bar").should.equal(true);
+  });
+});

--- a/test/perf.js
+++ b/test/perf.js
@@ -1,48 +1,59 @@
-describe("Tests to compare perf with morphdom", function(){
-    setup();
+describe("Tests to compare perf with morphdom", function () {
+  setup();
 
-    it('HTML5 Elements Sample Page', function(done)
-    {
-        runPerfTest("HTML5 Demo", "/test/perf/perf1.start", "/test/perf/perf1.end", done);
+  it("HTML5 Elements Sample Page", function (done) {
+    runPerfTest(
+      "HTML5 Demo",
+      "/test/perf/perf1.start",
+      "/test/perf/perf1.end",
+      done,
+    );
+  });
+
+  it("Large Table performance", function (done) {
+    runPerfTest(
+      "Large Table Perf",
+      "/test/perf/table.start",
+      "/test/perf/table.end",
+      done,
+    );
+  });
+
+  it("Checkboxes Performance", function (done) {
+    runPerfTest(
+      "Checkboxes Performance",
+      "/test/perf/checkboxes.start",
+      "/test/perf/checkboxes.start",
+      done,
+    );
+  });
+
+  function runPerfTest(testName, startUrl, endUrl, done) {
+    let startPromise = fetch(startUrl).then((value) => value.text());
+    let endPromise = fetch(endUrl).then((value) => value.text());
+    Promise.all([startPromise, endPromise]).then((value) => {
+      let start = value[0];
+      let end = value[1];
+
+      let startElt = make(start);
+      let endElt = make(end);
+      // // debugging output
+      // console.log("Content Size");
+      // console.log("  Start: " + start.length + " characters");
+      // console.log("  End  : " + end.length + " characters");
+      console.time("idiomorph timing");
+      Idiomorph.morph(startElt, endElt);
+      // startElt.outerHTML.should.equal(end);
+      console.timeEnd("idiomorph timing");
+
+      let startElt2 = make(start);
+      let endElt2 = make(end);
+      console.time("morphdom timing");
+      morphdom(startElt2, endElt2, {});
+      // wow morphdom doesn't match...
+      // startElt2.outerHTML.should.equal(end);
+      console.timeEnd("morphdom timing");
+      done();
     });
-
-    it('Large Table performance', function(done)
-    {
-        runPerfTest("Large Table Perf", "/test/perf/table.start", "/test/perf/table.end", done);
-    });
-
-    it('Checkboxes Performance', function(done)
-    {
-        runPerfTest("Checkboxes Performance", "/test/perf/checkboxes.start", "/test/perf/checkboxes.start", done);
-    });
-
-    function runPerfTest(testName, startUrl, endUrl, done) {
-        let startPromise = fetch(startUrl).then(value => value.text());
-        let endPromise = fetch(endUrl).then(value => value.text());
-        Promise.all([startPromise, endPromise]).then(value => {
-            let start = value[0];
-            let end = value[1];
-
-            let startElt = make(start);
-            let endElt = make(end);
-            // // debugging output
-            // console.log("Content Size");
-            // console.log("  Start: " + start.length + " characters");
-            // console.log("  End  : " + end.length + " characters");
-            console.time('idiomorph timing')
-            Idiomorph.morph(startElt, endElt);
-            // startElt.outerHTML.should.equal(end);
-            console.timeEnd('idiomorph timing')
-
-            let startElt2 = make(start);
-            let endElt2 = make(end);
-            console.time('morphdom timing')
-            morphdom(startElt2, endElt2, {});
-            // wow morphdom doesn't match...
-            // startElt2.outerHTML.should.equal(end);
-            console.timeEnd('morphdom timing')
-            done();
-        });
-    }
-
-})
+  }
+});

--- a/test/two-pass.js
+++ b/test/two-pass.js
@@ -1,111 +1,129 @@
-describe("Two-pass option for retaining more state", function(){
+describe("Two-pass option for retaining more state", function () {
+  beforeEach(function () {
+    clearWorkArea();
+  });
 
-    beforeEach(function() {
-        clearWorkArea();
-    });
-
-    it('fails to preserve all non-attribute element state with single-pass option', function()
-    {
-        getWorkArea().append(make(`
+  it("fails to preserve all non-attribute element state with single-pass option", function () {
+    getWorkArea().append(
+      make(`
             <div>
               <input type="checkbox" id="first">
               <input type="checkbox" id="second">
             </div>
-        `));
-        document.getElementById("first").indeterminate = true
-        document.getElementById("second").indeterminate = true
+        `),
+    );
+    document.getElementById("first").indeterminate = true;
+    document.getElementById("second").indeterminate = true;
 
-        let finalSrc = `
-            <div>
-              <input type="checkbox" id="second">
-              <input type="checkbox" id="first">
-            </div>
-        `;
-        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML', twoPass:false});
-
-        getWorkArea().innerHTML.should.equal(finalSrc);
-        const states = Array.from(getWorkArea().querySelectorAll("input")).map(e => e.indeterminate);
-        states.should.eql([true, false]);
-    });
-
-    it('preserves all non-attribute element state with two-pass option', function()
-    {
-        getWorkArea().append(make(`
-            <div>
-              <input type="checkbox" id="first">
-              <input type="checkbox" id="second">
-            </div>
-        `));
-        document.getElementById("first").indeterminate = true
-        document.getElementById("second").indeterminate = true
-
-        let finalSrc = `
+    let finalSrc = `
             <div>
               <input type="checkbox" id="second">
               <input type="checkbox" id="first">
             </div>
         `;
-        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true});
-
-        getWorkArea().innerHTML.should.equal(finalSrc);
-        const states = Array.from(getWorkArea().querySelectorAll("input")).map(e => e.indeterminate);
-        states.should.eql([true, true]);
+    Idiomorph.morph(getWorkArea(), finalSrc, {
+      morphStyle: "innerHTML",
+      twoPass: false,
     });
 
-    it('preserves all non-attribute element state with two-pass option and outerHTML morphStyle', function()
-    {
-        const div = make(`
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    const states = Array.from(getWorkArea().querySelectorAll("input")).map(
+      (e) => e.indeterminate,
+    );
+    states.should.eql([true, false]);
+  });
+
+  it("preserves all non-attribute element state with two-pass option", function () {
+    getWorkArea().append(
+      make(`
+            <div>
+              <input type="checkbox" id="first">
+              <input type="checkbox" id="second">
+            </div>
+        `),
+    );
+    document.getElementById("first").indeterminate = true;
+    document.getElementById("second").indeterminate = true;
+
+    let finalSrc = `
+            <div>
+              <input type="checkbox" id="second">
+              <input type="checkbox" id="first">
+            </div>
+        `;
+    Idiomorph.morph(getWorkArea(), finalSrc, {
+      morphStyle: "innerHTML",
+      twoPass: true,
+    });
+
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    const states = Array.from(getWorkArea().querySelectorAll("input")).map(
+      (e) => e.indeterminate,
+    );
+    states.should.eql([true, true]);
+  });
+
+  it("preserves all non-attribute element state with two-pass option and outerHTML morphStyle", function () {
+    const div = make(`
             <div>
               <input type="checkbox" id="first">
               <input type="checkbox" id="second">
             </div>
         `);
-        getWorkArea().append(div);
-        document.getElementById("first").indeterminate = true
-        document.getElementById("second").indeterminate = true
+    getWorkArea().append(div);
+    document.getElementById("first").indeterminate = true;
+    document.getElementById("second").indeterminate = true;
 
-        let finalSrc = `
+    let finalSrc = `
             <div>
               <input type="checkbox" id="second">
               <input type="checkbox" id="first">
             </div>
         `;
-        Idiomorph.morph(div, finalSrc, {morphStyle:'outerHTML',twoPass:true});
+    Idiomorph.morph(div, finalSrc, { morphStyle: "outerHTML", twoPass: true });
 
-        getWorkArea().innerHTML.should.equal(finalSrc);
-        const states = Array.from(getWorkArea().querySelectorAll("input")).map(e => e.indeterminate);
-        states.should.eql([true, true]);
-    });
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    const states = Array.from(getWorkArea().querySelectorAll("input")).map(
+      (e) => e.indeterminate,
+    );
+    states.should.eql([true, true]);
+  });
 
-    it('preserves non-attribute state when elements are moved to different levels of the DOM', function()
-    {
-        getWorkArea().append(make(`
+  it("preserves non-attribute state when elements are moved to different levels of the DOM", function () {
+    getWorkArea().append(
+      make(`
             <div>
               <input type="checkbox" id="first">
               <div>
                 <input type="checkbox" id="second">
               </div>
             </div>
-        `));
-        document.getElementById("first").indeterminate = true
-        document.getElementById("second").indeterminate = true
+        `),
+    );
+    document.getElementById("first").indeterminate = true;
+    document.getElementById("second").indeterminate = true;
 
-        let finalSrc = `
+    let finalSrc = `
             <div>
               <input type="checkbox" id="first">
               <input type="checkbox" id="second">
             </div>
         `;
-        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true});
-
-        getWorkArea().innerHTML.should.equal(finalSrc);
-        const states = Array.from(getWorkArea().querySelectorAll("input")).map(e => e.indeterminate);
-        states.should.eql([true, true]);
+    Idiomorph.morph(getWorkArea(), finalSrc, {
+      morphStyle: "innerHTML",
+      twoPass: true,
     });
 
-    it('preserves non-attribute state when elements are moved between different containers', function()
-    {
-        getWorkArea().append(make(`
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    const states = Array.from(getWorkArea().querySelectorAll("input")).map(
+      (e) => e.indeterminate,
+    );
+    states.should.eql([true, true]);
+  });
+
+  it("preserves non-attribute state when elements are moved between different containers", function () {
+    getWorkArea().append(
+      make(`
             <div>
               <div id="left">
                 <input type="checkbox" id="first">
@@ -114,11 +132,12 @@ describe("Two-pass option for retaining more state", function(){
                 <input type="checkbox" id="second">
               </div>
             </div>
-        `));
-        document.getElementById("first").indeterminate = true
-        document.getElementById("second").indeterminate = true
+        `),
+    );
+    document.getElementById("first").indeterminate = true;
+    document.getElementById("second").indeterminate = true;
 
-        let finalSrc = `
+    let finalSrc = `
             <div>
               <div id="left">
                 <input type="checkbox" id="second">
@@ -128,16 +147,21 @@ describe("Two-pass option for retaining more state", function(){
               </div>
             </div>
         `;
-        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true});
-
-        getWorkArea().innerHTML.should.equal(finalSrc);
-        const states = Array.from(getWorkArea().querySelectorAll("input")).map(e => e.indeterminate);
-        states.should.eql([true, true]);
+    Idiomorph.morph(getWorkArea(), finalSrc, {
+      morphStyle: "innerHTML",
+      twoPass: true,
     });
 
-    it('preserves non-attribute state when parents are reorderd', function()
-    {
-        getWorkArea().append(make(`
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    const states = Array.from(getWorkArea().querySelectorAll("input")).map(
+      (e) => e.indeterminate,
+    );
+    states.should.eql([true, true]);
+  });
+
+  it("preserves non-attribute state when parents are reorderd", function () {
+    getWorkArea().append(
+      make(`
             <div>
               <div id="left">
                 <input type="checkbox" id="first">
@@ -146,11 +170,12 @@ describe("Two-pass option for retaining more state", function(){
                 <input type="checkbox" id="second">
               </div>
             </div>
-        `));
-        document.getElementById("first").indeterminate = true
-        document.getElementById("second").indeterminate = true
+        `),
+    );
+    document.getElementById("first").indeterminate = true;
+    document.getElementById("second").indeterminate = true;
 
-        let finalSrc = `
+    let finalSrc = `
             <div>
               <div id="right">
                 <input type="checkbox" id="second">
@@ -160,73 +185,89 @@ describe("Two-pass option for retaining more state", function(){
               </div>
             </div>
         `;
-        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true});
-
-        getWorkArea().innerHTML.should.equal(finalSrc);
-        const states = Array.from(getWorkArea().querySelectorAll("input")).map(e => e.indeterminate);
-        states.should.eql([true, true]);
+    Idiomorph.morph(getWorkArea(), finalSrc, {
+      morphStyle: "innerHTML",
+      twoPass: true,
     });
 
-    it('preserves focus state with two-pass option and outerHTML morphStyle', function()
-    {
-        const div = make(`
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    const states = Array.from(getWorkArea().querySelectorAll("input")).map(
+      (e) => e.indeterminate,
+    );
+    states.should.eql([true, true]);
+  });
+
+  it("preserves focus state with two-pass option and outerHTML morphStyle", function () {
+    const div = make(`
             <div>
               <input type="text" id="first">
               <input type="text" id="second">
             </div>
         `);
-        getWorkArea().append(div);
-        document.getElementById("first").focus()
+    getWorkArea().append(div);
+    document.getElementById("first").focus();
 
-        let finalSrc = `
+    let finalSrc = `
             <div>
               <input type="text" id="second">
               <input type="text" id="first">
             </div>
         `;
-        Idiomorph.morph(div, finalSrc, {morphStyle:'outerHTML',twoPass:true});
+    Idiomorph.morph(div, finalSrc, { morphStyle: "outerHTML", twoPass: true });
 
-        getWorkArea().innerHTML.should.equal(finalSrc);
-        if(document.body.moveBefore) {
-          document.activeElement.outerHTML.should.equal(document.getElementById("first").outerHTML);
-        } else {
-          document.activeElement.outerHTML.should.equal(document.body.outerHTML);
-          console.log('preserves focus state with two-pass option and outerHTML morphStyle test needs moveBefore enabled to work properly')
-        }
-    });
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    if (document.body.moveBefore) {
+      document.activeElement.outerHTML.should.equal(
+        document.getElementById("first").outerHTML,
+      );
+    } else {
+      document.activeElement.outerHTML.should.equal(document.body.outerHTML);
+      console.log(
+        "preserves focus state with two-pass option and outerHTML morphStyle test needs moveBefore enabled to work properly",
+      );
+    }
+  });
 
-    it('preserves focus state when elements are moved to different levels of the DOM', function()
-    {
-        getWorkArea().append(make(`
+  it("preserves focus state when elements are moved to different levels of the DOM", function () {
+    getWorkArea().append(
+      make(`
             <div>
               <input type="text" id="first">
               <div>
                 <input type="text" id="second">
               </div>
             </div>
-        `));
-        document.getElementById("second").focus()
+        `),
+    );
+    document.getElementById("second").focus();
 
-        let finalSrc = `
+    let finalSrc = `
             <div>
               <input type="text" id="first">
               <input type="text" id="second">
             </div>
         `;
-        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true});
-
-        getWorkArea().innerHTML.should.equal(finalSrc);
-        if(document.body.moveBefore) {
-          document.activeElement.outerHTML.should.equal(document.getElementById("second").outerHTML);
-        } else {
-          document.activeElement.outerHTML.should.equal(document.body.outerHTML);
-          console.log('preserves focus state when elements are moved to different levels of the DOM test needs moveBefore enabled to work properly')
-        }
+    Idiomorph.morph(getWorkArea(), finalSrc, {
+      morphStyle: "innerHTML",
+      twoPass: true,
     });
 
-    it('preserves focus state when elements are moved between different containers', function()
-    {
-        getWorkArea().append(make(`
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    if (document.body.moveBefore) {
+      document.activeElement.outerHTML.should.equal(
+        document.getElementById("second").outerHTML,
+      );
+    } else {
+      document.activeElement.outerHTML.should.equal(document.body.outerHTML);
+      console.log(
+        "preserves focus state when elements are moved to different levels of the DOM test needs moveBefore enabled to work properly",
+      );
+    }
+  });
+
+  it("preserves focus state when elements are moved between different containers", function () {
+    getWorkArea().append(
+      make(`
             <div>
               <div id="left">
                 <input type="text" id="first">
@@ -235,10 +276,11 @@ describe("Two-pass option for retaining more state", function(){
                 <input type="text" id="second">
               </div>
             </div>
-        `));
-        document.getElementById("first").focus()
+        `),
+    );
+    document.getElementById("first").focus();
 
-        let finalSrc = `
+    let finalSrc = `
             <div>
               <div id="left">
                 <input type="text" id="second">
@@ -248,20 +290,27 @@ describe("Two-pass option for retaining more state", function(){
               </div>
             </div>
         `;
-        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true});
-
-        getWorkArea().innerHTML.should.equal(finalSrc);
-        if(document.body.moveBefore) {
-          document.activeElement.outerHTML.should.equal(document.getElementById("first").outerHTML);
-        } else {
-          document.activeElement.outerHTML.should.equal(document.body.outerHTML);
-          console.log('preserves focus state when elements are moved between different containers test needs moveBefore enabled to work properly')
-        }
+    Idiomorph.morph(getWorkArea(), finalSrc, {
+      morphStyle: "innerHTML",
+      twoPass: true,
     });
 
-    it('preserves focus state when parents are reorderd', function()
-    {
-        getWorkArea().append(make(`
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    if (document.body.moveBefore) {
+      document.activeElement.outerHTML.should.equal(
+        document.getElementById("first").outerHTML,
+      );
+    } else {
+      document.activeElement.outerHTML.should.equal(document.body.outerHTML);
+      console.log(
+        "preserves focus state when elements are moved between different containers test needs moveBefore enabled to work properly",
+      );
+    }
+  });
+
+  it("preserves focus state when parents are reorderd", function () {
+    getWorkArea().append(
+      make(`
             <div>
               <div id="left">
                 <input type="text" id="first">
@@ -270,10 +319,11 @@ describe("Two-pass option for retaining more state", function(){
                 <input type="text" id="second">
               </div>
             </div>
-        `));
-        document.getElementById("first").focus()
+        `),
+    );
+    document.getElementById("first").focus();
 
-        let finalSrc = `
+    let finalSrc = `
             <div>
               <div id="right">
                 <input type="text" id="second">
@@ -283,73 +333,99 @@ describe("Two-pass option for retaining more state", function(){
               </div>
             </div>
         `;
-        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true});
-
-        getWorkArea().innerHTML.should.equal(finalSrc);
-        if(document.body.moveBefore) {
-          document.activeElement.outerHTML.should.equal(document.getElementById("first").outerHTML);
-        } else {
-          document.activeElement.outerHTML.should.equal(document.body.outerHTML);
-          console.log('preserves focus state when parents are reorderd test needs moveBefore enabled to work properly')
-        }
+    Idiomorph.morph(getWorkArea(), finalSrc, {
+      morphStyle: "innerHTML",
+      twoPass: true,
     });
 
-    it('hooks work as expected', function()
-    {
-        let beginSrc =`
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    if (document.body.moveBefore) {
+      document.activeElement.outerHTML.should.equal(
+        document.getElementById("first").outerHTML,
+      );
+    } else {
+      document.activeElement.outerHTML.should.equal(document.body.outerHTML);
+      console.log(
+        "preserves focus state when parents are reorderd test needs moveBefore enabled to work properly",
+      );
+    }
+  });
+
+  it("hooks work as expected", function () {
+    let beginSrc = `
             <div>
               <input type="checkbox" id="first">
               <input type="checkbox" id="second">
             </div>
         `.trim();
-        getWorkArea().append(make(beginSrc));
+    getWorkArea().append(make(beginSrc));
 
-        let finalSrc = `
+    let finalSrc = `
             <div>
               <input type="checkbox" id="second">
               <input type="checkbox" id="first">
             </div>
         `.trim();
 
-        let wrongHookCalls = [];
-        let wrongHookHandler = name => {
-            return node => {
-                if (node.nodeType !== Node.ELEMENT_NODE) return;
-                wrongHookCalls.push([name, node.outerHTML]);
-            }
-        }
+    let wrongHookCalls = [];
+    let wrongHookHandler = (name) => {
+      return (node) => {
+        if (node.nodeType !== Node.ELEMENT_NODE) return;
+        wrongHookCalls.push([name, node.outerHTML]);
+      };
+    };
 
-        let calls = [];
+    let calls = [];
 
-        Idiomorph.morph(getWorkArea(), finalSrc, {morphStyle:'innerHTML',twoPass:true,callbacks:{
-            beforeNodeAdded: wrongHookHandler("beforeNodeAdded"),
-            afterNodeAdded: wrongHookHandler("afterNodeAdded"),
-            beforeNodeRemoved: wrongHookHandler("beforeNodeRemoved"),
-            afterNodeRemoved: wrongHookHandler("afterNodeRemoved"),
-            beforeNodeMorphed: (oldNode, newNode) => {
-                if (oldNode.nodeType !== Node.ELEMENT_NODE) return;
-                calls.push(["before", oldNode.outerHTML, newNode.outerHTML]);
-            },
-            afterNodeMorphed: (oldNode, newNode) => {
-                if (oldNode.nodeType !== Node.ELEMENT_NODE) return;
-                calls.push(["after", oldNode.outerHTML, newNode.outerHTML]);
-            },
-        }});
-
-        getWorkArea().innerHTML.should.equal(finalSrc);
-
-        wrongHookCalls.should.eql([]);
-        calls.should.eql([
-            ["before", beginSrc, finalSrc],
-            ["before", `<input type="checkbox" id="second">`, `<input type="checkbox" id="second">`],
-            ["after", `<input type="checkbox" id="second">`, `<input type="checkbox" id="second">`],
-            ["after",
-              finalSrc,
-              "<div>\n              <input type=\"checkbox\" id=\"second\">\n              </div>",
-            ],
-            ["before", `<input type="checkbox" id="first">`, `<input type="checkbox" id="first">`],
-            ["after", `<input type="checkbox" id="first">`, `<input type="checkbox" id="first">`],
-        ]);
-
+    Idiomorph.morph(getWorkArea(), finalSrc, {
+      morphStyle: "innerHTML",
+      twoPass: true,
+      callbacks: {
+        beforeNodeAdded: wrongHookHandler("beforeNodeAdded"),
+        afterNodeAdded: wrongHookHandler("afterNodeAdded"),
+        beforeNodeRemoved: wrongHookHandler("beforeNodeRemoved"),
+        afterNodeRemoved: wrongHookHandler("afterNodeRemoved"),
+        beforeNodeMorphed: (oldNode, newNode) => {
+          if (oldNode.nodeType !== Node.ELEMENT_NODE) return;
+          calls.push(["before", oldNode.outerHTML, newNode.outerHTML]);
+        },
+        afterNodeMorphed: (oldNode, newNode) => {
+          if (oldNode.nodeType !== Node.ELEMENT_NODE) return;
+          calls.push(["after", oldNode.outerHTML, newNode.outerHTML]);
+        },
+      },
     });
+
+    getWorkArea().innerHTML.should.equal(finalSrc);
+
+    wrongHookCalls.should.eql([]);
+    calls.should.eql([
+      ["before", beginSrc, finalSrc],
+      [
+        "before",
+        `<input type="checkbox" id="second">`,
+        `<input type="checkbox" id="second">`,
+      ],
+      [
+        "after",
+        `<input type="checkbox" id="second">`,
+        `<input type="checkbox" id="second">`,
+      ],
+      [
+        "after",
+        finalSrc,
+        '<div>\n              <input type="checkbox" id="second">\n              </div>',
+      ],
+      [
+        "before",
+        `<input type="checkbox" id="first">`,
+        `<input type="checkbox" id="first">`,
+      ],
+      [
+        "after",
+        `<input type="checkbox" id="first">`,
+        `<input type="checkbox" id="first">`,
+      ],
+    ]);
+  });
 });

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -1,4 +1,8 @@
-import { chromeLauncher, summaryReporter, defaultReporter } from "@web/test-runner";
+import {
+  chromeLauncher,
+  summaryReporter,
+  defaultReporter,
+} from "@web/test-runner";
 import { exec } from "child_process";
 import failOnly from "./test/lib/fail-only.mjs";
 
@@ -43,26 +47,27 @@ let config = {
   nodeResolve: true,
   coverage: true,
   coverageConfig: {
-    include: ['src/**/*'],
+    include: ["src/**/*"],
   },
   files: "test/*.js",
   plugins: [failOnly],
-  reporters: [
-    summaryReporter(),
-    defaultReporter(),
-  ],
+  reporters: [summaryReporter(), defaultReporter()],
 };
 
 if (process.env.USE_MOVE_BEFORE) {
   // configure chrome to use a custom profile directory we control
   config.browsers = [
-    chromeLauncher({ launchOptions: { args: ['--user-data-dir=test/chrome-profile'] } })
-  ]
-  exec([
-    'rm -rf test/chrome-profile', // clear profile out from last run
-    'mkdir -p test/chrome-profile', // create from scratch
-    `echo '{"browser":{"enabled_labs_experiments":["atomic-move@1"]}}' > test/chrome-profile/Local\\ State`, // enable experiment
-  ].join(" && "));
+    chromeLauncher({
+      launchOptions: { args: ["--user-data-dir=test/chrome-profile"] },
+    }),
+  ];
+  exec(
+    [
+      "rm -rf test/chrome-profile", // clear profile out from last run
+      "mkdir -p test/chrome-profile", // create from scratch
+      `echo '{"browser":{"enabled_labs_experiments":["atomic-move@1"]}}' > test/chrome-profile/Local\\ State`, // enable experiment
+    ].join(" && "),
+  );
 }
 
 export default config;


### PR DESCRIPTION
Okay, @1cg , here's the first sample of what a PR for this might look like. I'm betting you'll have some opinions about this!

Questions:
1. Prettier defaults to 2-space tabs, rather than your 4 spaces. Do you want this to be changed to 4 in the prettier config?
2. Any other config settings you wanna tweak?
3. Turns out it can tidy up Markdown. That seems... nice? Or should we not bother and add `*.md` it to `.prettierignore`
4. How should we enforce this, moving forward? It'd be trivial to add a job to the CI to fail the build if prettier wasn't ran, for example. But then we'd need to communicate to PR authors to be sure to run `npm run format` before committing. That's some minor added friction.