### PR TITLE
[WIP] Compress to a single-pass

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -1249,22 +1249,10 @@ var Idiomorph = (function () {
             if (matchElement.parentElement?.moveBefore) {
               // @ts-ignore - use proposed moveBefore feature
               matchElement.parentElement.moveBefore(element, matchElement);
-              while (matchElement.hasChildNodes()) {
-                // @ts-ignore - use proposed moveBefore feature
-                element.moveBefore(matchElement.firstChild, null);
-              }
             } else {
               matchElement.before(element);
-              while (matchElement.firstChild) {
-                element.insertBefore(matchElement.firstChild, null);
-              }
             }
-            if (
-              ctx.callbacks.beforeNodeMorphed(element, matchElement) !== false
-            ) {
-              syncNodeFrom(matchElement, element, ctx);
-              ctx.callbacks.afterNodeMorphed(element, matchElement);
-            }
+            morphOldNodeTo(element, matchElement, ctx);
             matchElement.remove();
           }
         });

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -35,25 +35,49 @@ describe("Bootstrap test", function () {
 
   it("basic deep morph works", function (done) {
     let div1 = make(
-      '<div id="root1"><div><div id="d1">A</div></div><div><div id="d2">B</div></div><div><div id="d3">C</div></div></div>',
+      `
+      <div id="root1">
+        <div>
+          <div id="d1">A</div>
+        </div>
+        <div>
+          <div id="d2">B</div>
+        </div>
+        <div>
+          <div id="d3">C</div>
+        </div>
+      </div>`.trim(),
     );
 
     let d1 = div1.querySelector("#d1");
     let d2 = div1.querySelector("#d2");
     let d3 = div1.querySelector("#d3");
 
-    let morphTo =
-      '<div id="root1"><div><div id="d2">E</div></div><div><div id="d3">F</div></div><div><div id="d1">D</div></div></div>';
+    let morphTo = `
+      <div id="root1">
+        <div>
+          <div id="d2">E</div>
+        </div>
+        <div>
+          <div id="d3">F</div>
+        </div>
+        <div>
+          <div id="d1">D</div>
+        </div>
+      </div>`.trim();
     let div2 = make(morphTo);
 
     print(div1);
     Idiomorph.morph(div1, div2);
     print(div1);
 
-    // first paragraph should have been discarded in favor of later matches
-    d1.innerHTML.should.not.equal("D");
-
-    // second and third paragraph should have morphed
+    if (Idiomorph.defaults.twoPass) {
+      // all three paragraphs should have been morphed in twoPass mode
+      d1.innerHTML.should.equal("D");
+    } else {
+      // default mode deletes and re-adds
+      d1.innerHTML.should.not.equal("D");
+    }
     d2.innerHTML.should.equal("E");
     d3.innerHTML.should.equal("F");
 

--- a/test/two-pass.js
+++ b/test/two-pass.js
@@ -195,6 +195,39 @@ describe("Two-pass option for retaining more state", function () {
     states.should.eql([true, true]);
   });
 
+  it("preserves focus state when focused element is moved", function () {
+    getWorkArea().innerHTML = `
+            <div>
+              <input type="text" id="first">
+            </div>
+            <div>
+              <input type="text" id="second">
+            </div>
+        `;
+    document.getElementById("second").focus();
+
+    let finalSrc = `
+            <div>
+              <input type="text" id="first">
+              <input type="text" id="second">
+            </div>
+        `;
+    Idiomorph.morph(getWorkArea(), finalSrc, { morphStyle: "innerHTML", twoPass: true });
+
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    if (document.body.moveBefore) {
+      document.activeElement.outerHTML.should.equal(
+        document.getElementById("second").outerHTML,
+      );
+    } else {
+      document.activeElement.outerHTML.should.equal(document.body.outerHTML);
+      console.log(
+        "preserves focus state when focused element is moved needs moveBefore enabled to work properly",
+      );
+    }
+  });
+
+
   it("preserves focus state with two-pass option and outerHTML morphStyle", function () {
     const div = make(`
             <div>

--- a/test/two-pass.js
+++ b/test/two-pass.js
@@ -214,16 +214,9 @@ describe("Two-pass option for retaining more state", function () {
     Idiomorph.morph(div, finalSrc, { morphStyle: "outerHTML", twoPass: true });
 
     getWorkArea().innerHTML.should.equal(finalSrc);
-    if (document.body.moveBefore) {
-      document.activeElement.outerHTML.should.equal(
-        document.getElementById("first").outerHTML,
-      );
-    } else {
-      document.activeElement.outerHTML.should.equal(document.body.outerHTML);
-      console.log(
-        "preserves focus state with two-pass option and outerHTML morphStyle test needs moveBefore enabled to work properly",
-      );
-    }
+    document.activeElement.outerHTML.should.equal(
+      document.getElementById("first").outerHTML,
+    );
   });
 
   it("preserves focus state when elements are moved to different levels of the DOM", function () {
@@ -337,16 +330,9 @@ describe("Two-pass option for retaining more state", function () {
     });
 
     getWorkArea().innerHTML.should.equal(finalSrc);
-    if (document.body.moveBefore) {
-      document.activeElement.outerHTML.should.equal(
-        document.getElementById("first").outerHTML,
-      );
-    } else {
-      document.activeElement.outerHTML.should.equal(document.body.outerHTML);
-      console.log(
-        "preserves focus state when parents are reorderd test needs moveBefore enabled to work properly",
-      );
-    }
+    document.activeElement.outerHTML.should.equal(
+      document.getElementById("first").outerHTML,
+    );
   });
 
   it("hooks work as expected", function () {
@@ -410,11 +396,6 @@ describe("Two-pass option for retaining more state", function () {
         `<input type="checkbox" id="second">`,
       ],
       [
-        "after",
-        finalSrc,
-        '<div>\n              <input type="checkbox" id="second">\n              </div>',
-      ],
-      [
         "before",
         `<input type="checkbox" id="first">`,
         `<input type="checkbox" id="first">`,
@@ -423,6 +404,11 @@ describe("Two-pass option for retaining more state", function () {
         "after",
         `<input type="checkbox" id="first">`,
         `<input type="checkbox" id="first">`,
+      ],
+      [
+        "after",
+        '<div>\n              <input type="checkbox" id="second">\n              <input type="checkbox" id="first">\n            </div>',
+        '<div>\n              <input type="checkbox" id="second">\n              <input type="checkbox" id="first">\n            </div>',
       ],
     ]);
   });


### PR DESCRIPTION
This PR attempts to improve the algorithm further by removing the second pass. Rather than moving nodes to the pantry, and then back in later, it moves them to the correct place all within the first (and only) pass.

Note that this is an evolution of the v0.4.0 two-pass algorithm, and is behind the same option, so default mode still behaves like v0.3.0, and one must still enable the new algorithm via the `twoPass` option (which has become a bit of a misnomer).

Benefits:
1. No more need for the abstraction-leaking `beforeNodePantried` callback. If you are doing interesting things with any of the other hooks, e.g. `data-turbo-permanent`, you'd often need to prevent the pantrying process from flattening the node trees that entered it, and thus you'd need to know how the internals of the pantrying process worked, and that there was a pantrying process at all, for that matter. This PR removes the hook, and the need for it.
2. Hooks are called in the order one would expect, and with the arguments one would expect. Two-pass mode resulted in minor changes to both in v0.4.0. This PR results in hook behavior that is more correct than both v0.3.0 and v0.4.0.
3. Many minor suboptimal situations have become optimal. For more details, see the test changes in the diff. 
4. Less DOM operations than v0.4.0, so maybe more performant?

Finally, as far as I can tell, there are no downsides to this new approach, but I welcome any skeptical scrutiny to make this as good as it can be! Can we find any regressions from v0.3.0 or v0.4.0?

P.S. First two commits are from https://github.com/bigskysoftware/idiomorph/pull/83 , which is a bugfix and should be evaluated separately from the outcome of this. I'll rebase once that gets merged.