### PR TITLE
Preserve active element's focus and selection by morphing around it, when possible

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -1249,22 +1249,10 @@ var Idiomorph = (function () {
             if (matchElement.parentElement?.moveBefore) {
               // @ts-ignore - use proposed moveBefore feature
               matchElement.parentElement.moveBefore(element, matchElement);
-              while (matchElement.hasChildNodes()) {
-                // @ts-ignore - use proposed moveBefore feature
-                element.moveBefore(matchElement.firstChild, null);
-              }
             } else {
               matchElement.before(element);
-              while (matchElement.firstChild) {
-                element.insertBefore(matchElement.firstChild, null);
-              }
             }
-            if (
-              ctx.callbacks.beforeNodeMorphed(element, matchElement) !== false
-            ) {
-              syncNodeFrom(matchElement, element, ctx);
-              ctx.callbacks.afterNodeMorphed(element, matchElement);
-            }
+            morphOldNodeTo(element, matchElement, ctx);
             matchElement.remove();
           }
         });

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -35,25 +35,49 @@ describe("Bootstrap test", function () {
 
   it("basic deep morph works", function (done) {
     let div1 = make(
-      '<div id="root1"><div><div id="d1">A</div></div><div><div id="d2">B</div></div><div><div id="d3">C</div></div></div>',
+      `
+      <div id="root1">
+        <div>
+          <div id="d1">A</div>
+        </div>
+        <div>
+          <div id="d2">B</div>
+        </div>
+        <div>
+          <div id="d3">C</div>
+        </div>
+      </div>`.trim(),
     );
 
     let d1 = div1.querySelector("#d1");
     let d2 = div1.querySelector("#d2");
     let d3 = div1.querySelector("#d3");
 
-    let morphTo =
-      '<div id="root1"><div><div id="d2">E</div></div><div><div id="d3">F</div></div><div><div id="d1">D</div></div></div>';
+    let morphTo = `
+      <div id="root1">
+        <div>
+          <div id="d2">E</div>
+        </div>
+        <div>
+          <div id="d3">F</div>
+        </div>
+        <div>
+          <div id="d1">D</div>
+        </div>
+      </div>`.trim();
     let div2 = make(morphTo);
 
     print(div1);
     Idiomorph.morph(div1, div2);
     print(div1);
 
-    // first paragraph should have been discarded in favor of later matches
-    d1.innerHTML.should.not.equal("D");
-
-    // second and third paragraph should have morphed
+    if (Idiomorph.defaults.twoPass) {
+      // all three paragraphs should have been morphed in twoPass mode
+      d1.innerHTML.should.equal("D");
+    } else {
+      // default mode deletes and re-adds
+      d1.innerHTML.should.not.equal("D");
+    }
     d2.innerHTML.should.equal("E");
     d3.innerHTML.should.equal("F");
 

--- a/test/two-pass.js
+++ b/test/two-pass.js
@@ -195,6 +195,39 @@ describe("Two-pass option for retaining more state", function () {
     states.should.eql([true, true]);
   });
 
+  it("preserves focus state when focused element is moved", function () {
+    getWorkArea().innerHTML = `
+            <div>
+              <input type="text" id="first">
+            </div>
+            <div>
+              <input type="text" id="second">
+            </div>
+        `;
+    document.getElementById("second").focus();
+
+    let finalSrc = `
+            <div>
+              <input type="text" id="first">
+              <input type="text" id="second">
+            </div>
+        `;
+    Idiomorph.morph(getWorkArea(), finalSrc, { morphStyle: "innerHTML", twoPass: true });
+
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    if (document.body.moveBefore) {
+      document.activeElement.outerHTML.should.equal(
+        document.getElementById("second").outerHTML,
+      );
+    } else {
+      document.activeElement.outerHTML.should.equal(document.body.outerHTML);
+      console.log(
+        "preserves focus state when focused element is moved needs moveBefore enabled to work properly",
+      );
+    }
+  });
+
+
   it("preserves focus state with two-pass option and outerHTML morphStyle", function () {
     const div = make(`
             <div>

--- a/test/two-pass.js
+++ b/test/two-pass.js
@@ -195,39 +195,6 @@ describe("Two-pass option for retaining more state", function () {
     states.should.eql([true, true]);
   });
 
-  it("preserves focus state when focused element is moved", function () {
-    getWorkArea().innerHTML = `
-            <div>
-              <input type="text" id="first">
-            </div>
-            <div>
-              <input type="text" id="second">
-            </div>
-        `;
-    document.getElementById("second").focus();
-
-    let finalSrc = `
-            <div>
-              <input type="text" id="first">
-              <input type="text" id="second">
-            </div>
-        `;
-    Idiomorph.morph(getWorkArea(), finalSrc, { morphStyle: "innerHTML", twoPass: true });
-
-    getWorkArea().innerHTML.should.equal(finalSrc);
-    if (document.body.moveBefore) {
-      document.activeElement.outerHTML.should.equal(
-        document.getElementById("second").outerHTML,
-      );
-    } else {
-      document.activeElement.outerHTML.should.equal(document.body.outerHTML);
-      console.log(
-        "preserves focus state when focused element is moved needs moveBefore enabled to work properly",
-      );
-    }
-  });
-
-
   it("preserves focus state with two-pass option and outerHTML morphStyle", function () {
     const div = make(`
             <div>
@@ -249,6 +216,32 @@ describe("Two-pass option for retaining more state", function () {
     getWorkArea().innerHTML.should.equal(finalSrc);
     document.activeElement.outerHTML.should.equal(
       document.getElementById("first").outerHTML,
+    );
+  });
+
+  it("preserves focus state when previous element is replaced", function () {
+    getWorkArea().innerHTML = `
+            <div>
+              <a></a>
+              <input type="text" id="focus">
+            </div>
+        `;
+    document.getElementById("focus").focus();
+
+    let finalSrc = `
+            <div>
+              <b></b>
+              <input type="text" id="focus">
+            </div>
+        `;
+    Idiomorph.morph(getWorkArea(), finalSrc, {
+      morphStyle: "innerHTML",
+      twoPass: true,
+    });
+
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    document.activeElement.outerHTML.should.equal(
+      document.getElementById("focus").outerHTML,
     );
   });
 
@@ -289,7 +282,35 @@ describe("Two-pass option for retaining more state", function () {
     }
   });
 
-  it("preserves focus state when elements are moved between different containers", function () {
+  it("preserves focus state when focused element is moved between anonymous containers", function () {
+    getWorkArea().innerHTML = `
+            <div>
+              <input type="text" id="first">
+            </div>
+            <div>
+              <input type="text" id="second">
+            </div>
+        `;
+    document.getElementById("second").focus();
+
+    let finalSrc = `
+            <div>
+              <input type="text" id="first">
+              <input type="text" id="second">
+            </div>
+        `;
+    Idiomorph.morph(getWorkArea(), finalSrc, {
+      morphStyle: "innerHTML",
+      twoPass: true,
+    });
+
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    document.activeElement.outerHTML.should.equal(
+      document.getElementById("second").outerHTML,
+    );
+  });
+
+  it("preserves focus state when elements are moved between IDed containers", function () {
     getWorkArea().append(
       make(`
             <div>
@@ -327,33 +348,33 @@ describe("Two-pass option for retaining more state", function () {
     } else {
       document.activeElement.outerHTML.should.equal(document.body.outerHTML);
       console.log(
-        "preserves focus state when elements are moved between different containers test needs moveBefore enabled to work properly",
+        "preserves focus state when elements are moved between IDed containers test needs moveBefore enabled to work properly",
       );
     }
   });
 
-  it("preserves focus state when parents are reorderd", function () {
+  it("preserves focus state when parents are reordered", function () {
     getWorkArea().append(
       make(`
             <div>
-              <div id="left">
-                <input type="text" id="first">
+              <div id="with-focus">
+                <input type="text" id="focus">
               </div>
-              <div id="right">
-                <input type="text" id="second">
+              <div id="with-other">
+                <input type="text" id="other">
               </div>
             </div>
         `),
     );
-    document.getElementById("first").focus();
+    document.getElementById("focus").focus();
 
     let finalSrc = `
             <div>
-              <div id="right">
-                <input type="text" id="second">
+              <div id="with-other">
+                <input type="text" id="other">
               </div>
-              <div id="left">
-                <input type="text" id="first">
+              <div id="with-focus">
+                <input type="text" id="focus">
               </div>
             </div>
         `;
@@ -362,10 +383,10 @@ describe("Two-pass option for retaining more state", function () {
       twoPass: true,
     });
 
-    getWorkArea().innerHTML.should.equal(finalSrc);
     document.activeElement.outerHTML.should.equal(
-      document.getElementById("first").outerHTML,
+      document.getElementById("focus").outerHTML,
     );
+    getWorkArea().innerHTML.should.equal(finalSrc);
   });
 
   it("hooks work as expected", function () {

--- a/test/two-pass.js
+++ b/test/two-pass.js
@@ -214,16 +214,9 @@ describe("Two-pass option for retaining more state", function () {
     Idiomorph.morph(div, finalSrc, { morphStyle: "outerHTML", twoPass: true });
 
     getWorkArea().innerHTML.should.equal(finalSrc);
-    if (document.body.moveBefore) {
-      document.activeElement.outerHTML.should.equal(
-        document.getElementById("first").outerHTML,
-      );
-    } else {
-      document.activeElement.outerHTML.should.equal(document.body.outerHTML);
-      console.log(
-        "preserves focus state with two-pass option and outerHTML morphStyle test needs moveBefore enabled to work properly",
-      );
-    }
+    document.activeElement.outerHTML.should.equal(
+      document.getElementById("first").outerHTML,
+    );
   });
 
   it("preserves focus state when elements are moved to different levels of the DOM", function () {
@@ -337,16 +330,9 @@ describe("Two-pass option for retaining more state", function () {
     });
 
     getWorkArea().innerHTML.should.equal(finalSrc);
-    if (document.body.moveBefore) {
-      document.activeElement.outerHTML.should.equal(
-        document.getElementById("first").outerHTML,
-      );
-    } else {
-      document.activeElement.outerHTML.should.equal(document.body.outerHTML);
-      console.log(
-        "preserves focus state when parents are reorderd test needs moveBefore enabled to work properly",
-      );
-    }
+    document.activeElement.outerHTML.should.equal(
+      document.getElementById("first").outerHTML,
+    );
   });
 
   it("hooks work as expected", function () {
@@ -410,11 +396,6 @@ describe("Two-pass option for retaining more state", function () {
         `<input type="checkbox" id="second">`,
       ],
       [
-        "after",
-        finalSrc,
-        '<div>\n              <input type="checkbox" id="second">\n              </div>',
-      ],
-      [
         "before",
         `<input type="checkbox" id="first">`,
         `<input type="checkbox" id="first">`,
@@ -423,6 +404,11 @@ describe("Two-pass option for retaining more state", function () {
         "after",
         `<input type="checkbox" id="first">`,
         `<input type="checkbox" id="first">`,
+      ],
+      [
+        "after",
+        '<div>\n              <input type="checkbox" id="second">\n              <input type="checkbox" id="first">\n            </div>',
+        '<div>\n              <input type="checkbox" id="second">\n              <input type="checkbox" id="first">\n            </div>',
       ],
     ]);
   });


### PR DESCRIPTION
Note: Builds on top of https://github.com/bigskysoftware/idiomorph/pull/84 , so please review just the diff of the last commit: https://github.com/bigskysoftware/idiomorph/commit/50b6e517524d854f091e2766e94b2e79862b5c8e . If #84 gets merged, I'll rebase for a easier diff.

## Overview

The new two-pass algorithm is a big improvement maintaining hidden state and element identity, but since more nodes are getting moved around vs v0.3.0, its more likely that the currently focused element (or its ancestor) will get moved, and focus and/or selection will be lost. Aside from being a regression in fidelity, this has frustrating real-world consequences, at least in the context of a real-time collaborative app.

This PR aims to preserve focus and selection across morphs by morphing around the active element and its ancestors, thus ensuring they never get moved.

## Implementation

This strategy has two steps:
1. When we build the morph context, we take the active element, find its match in the new content, and trace them both back to their respective top-most element that was passed to `Idiomorph.morph(old, new)`. If both traced paths are have the same sequence of `tagName#id`, preserving the focused element is possible, and we save a map of this information in the context.
2. Later on, while morphing, we check the map to see if we're within the critical ancestor path of the active element, and if we're about to morph the next node in that critical path. If we are, and the node is too far to the right, it would normally be moved into place, breaking focus. So if all this is true, we prime the situation by "moving" the active node into place, by repeatedly moving the current node to the end of the list until the active node is in the correct `insertionPoint` position. Once this is done, we can just continue morphing as normal. In this way, the active element and its ancestors are never moved, and focus is preserved.

## Notes / Caveats / Limitations:

When we have `moveBefore`, none of this is necessary, so we check for its existence while building the morph context, and if so none of this gets run. However, when we don't have `moveBefore`, there are three situations where this PR doesn't preserve focus. All of them might become the subject of future improvements, but they're out of scope for this PR.

1. If the active element changes levels in the DOM heirarchy, or if any element along the crticial path changes their tag name. This is simply impossible with current APIs. We could look into manually restoring focus post-morph in these cases, but again, that's out-of-scope for this PR.
2. A element along the critical path changes ids. Technically we could mutate the old id to the new id in this case and preserve focus, but that breaks our rule of maintaining identity for IDed elements. This might be reasonable to special-case, in that maybe there's no circumstance where a parent node of a focused element could have hidden state, and thus it would be safe to perform this mutation, but I haven't thought it through yet. 
3. The active element is anonymous, i.e. has no id attribute. This may or may not be solvable in a deterministic way. We might want to fall back to just trying to avoid moving the current element or its ancestors, but I haven't thought it through yet.