### PR TITLE
Implement better soft and id matching

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -390,6 +390,8 @@ var Idiomorph = (function () {
        */
       function findBestMatch(ctx, node, startPoint, endPoint) {
         let softMatch = null;
+        let nextSibling = node.nextSibling; 
+        let siblingSoftMatchCount = 0;
 
         let cursor = startPoint;
         while (cursor && cursor != endPoint) {
@@ -400,7 +402,7 @@ var Idiomorph = (function () {
             }
 
             // we haven't yet saved a soft match fallback
-            if (!softMatch) {
+            if (softMatch === null) {
               // the current soft match will hard match something else in the future, leave it
               if (!ctx.idMap.has(cursor)) {
                 // optimization: if node can't id set match, we can just return the soft match immediately
@@ -413,10 +415,24 @@ var Idiomorph = (function () {
               }
             }
           }
+          if (nextSibling && isSoftMatch(cursor, nextSibling)) {
+            // the next new node has a soft match with this node, so
+            // increment the count of future soft matches
+            siblingSoftMatchCount++;
+            nextSibling =  nextSibling.nextSibling;
+    
+            // If there are two future soft matches, block soft matching allow the siblings to soft match
+            // so that we don't consume future soft matches for the sake of the current node
+            if (siblingSoftMatchCount >= 2) {
+              // set it undefined to block future softmatches
+              softMatch = undefined;
+            }
+          }
+  
           cursor = cursor.nextSibling;
         }
 
-        return softMatch;
+        return softMatch || null;
       }
 
       /**

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -392,6 +392,10 @@ var Idiomorph = (function () {
         let softMatch = null;
         let nextSibling = node.nextSibling; 
         let siblingSoftMatchCount = 0;
+        let discardMatchCount = 0;
+
+        // max id matches we are willing to discard in our search
+        const nodeMatchCount = ctx.idMap.get(node)?.size || 0;
 
         let cursor = startPoint;
         while (cursor && cursor != endPoint) {
@@ -415,6 +419,16 @@ var Idiomorph = (function () {
               }
             }
           }
+          // check for ids we may be discarding when matching nodes with ids
+          if (nodeMatchCount) {
+            discardMatchCount += ctx.idMap.get(cursor)?.size || 0;
+            if (discardMatchCount > nodeMatchCount) {
+              // if we are going to discard more ids than the node contains then
+              // we do not have a good candidate for an id match, so return
+              break;
+            }
+          }
+
           if (nextSibling && isSoftMatch(cursor, nextSibling)) {
             // the next new node has a soft match with this node, so
             // increment the count of future soft matches
@@ -428,7 +442,7 @@ var Idiomorph = (function () {
               softMatch = undefined;
             }
           }
-  
+
           cursor = cursor.nextSibling;
         }
 

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -419,14 +419,12 @@ var Idiomorph = (function () {
               }
             }
           }
-          // check for ids we may be discarding when matching nodes with ids
-          if (nodeMatchCount) {
-            discardMatchCount += ctx.idMap.get(cursor)?.size || 0;
-            if (discardMatchCount > nodeMatchCount) {
-              // if we are going to discard more ids than the node contains then
-              // we do not have a good candidate for an id match, so return
-              break;
-            }
+          // check for ids we may be discarding when matching
+          discardMatchCount += ctx.idMap.get(cursor)?.size || 0;
+          if (discardMatchCount > nodeMatchCount) {
+            // if we are going to discard more ids than the node contains then
+            // we do not have a good candidate for an id match, so return
+            break;
           }
 
           if (nextSibling && isSoftMatch(cursor, nextSibling)) {

--- a/test/mw-temp.js
+++ b/test/mw-temp.js
@@ -1,7 +1,7 @@
 describe("Michael West temp tests", function () {
   setup();
 
-  it.skip("Show findSoftMatch aborting on two future soft matches", function () {
+  it("Show findSoftMatch aborting on two future soft matches", function () {
     // when nodes can't be softMatched because they have different types it will scan ahead
     // but it aborts the scan ahead if it finds two nodes ahead in both the new and old content
     // that softmatch so it can just insert the mis matched node it is on and get to the matching.

--- a/test/mw-temp.js
+++ b/test/mw-temp.js
@@ -1,64 +1,6 @@
 describe("Michael West temp tests", function () {
   setup();
 
-  it("Show findSoftMatch aborting on two future soft matches", function () {
-    // when nodes can't be softMatched because they have different types it will scan ahead
-    // but it aborts the scan ahead if it finds two nodes ahead in both the new and old content
-    // that softmatch so it can just insert the mis matched node it is on and get to the matching.
-    assertOps(
-      "<section><h1></h1><h2></h2><div></div></section>",
-      "<section><div>Alert</div><h1></h1><h2></h2><div></div></section>",
-      [
-        [
-          "Morphed",
-          "<section><h1></h1><h2></h2><div></div></section>",
-          "<section><div>Alert</div><h1></h1><h2></h2><div></div></section>",
-        ],
-        ["Added", "<div>Alert</div>"],
-        ["Morphed", "<h1></h1>", "<h1></h1>"],
-        ["Morphed", "<h2></h2>", "<h2></h2>"],
-        ["Morphed", "<div></div>", "<div></div>"],
-      ],
-    );
-  });
-
-  it.skip("findIdSetMatch rejects morphing node that would lose more IDs", function () {
-    // here the findIdSetMatch function when it finds a node with id's it will track how many
-    // id matches in this node and then as it searches for a matching node it will track
-    // how many id's in the content it would have to remove before it finds a match
-    // if it finds more ids are going to match in-between nodes it aborts matching to
-    // allow better matching with less dom updates.
-    assertOps(
-      `<div>` +
-        `<label>1</label><input id="first">` +
-        `<label>2</label><input id="second">` +
-        `<label>3</label><input id="third">` +
-        `</div>`,
-
-      `<div>` +
-        `<label>3</label><input id="third">` +
-        `<label>1</label><input id="first">` +
-        `<label>2</label><input id="second">` +
-        `</div>`,
-      [
-        [
-          "Morphed",
-          '<div><label>1</label><input id="first"><label>2</label><input id="second"><label>3</label><input id="third"></div>',
-          '<div><label>3</label><input id="third"><label>1</label><input id="first"><label>2</label><input id="second"></div>',
-        ],
-        ["Morphed", "<label>1</label>", "<label>3</label>"],
-        ["Morphed", "1", "3"],
-        ["Morphed", '<input id="third">', '<input id="third">'],
-        ["Added", "<label>1</label>"],
-        ["Morphed", '<input id="first">', '<input id="first">'],
-        ["Morphed", "<label>2</label>", "<label>2</label>"],
-        ["Morphed", "2", "2"],
-        ["Morphed", '<input id="second">', '<input id="second">'],
-        ["Removed", "<label>3</label>"],
-      ],
-    );
-  });
-
   // five tests that show it is possible with the right activeElement preservation tricks you could preserve focus both ways
   it.skip("preserves focus state and outerHTML morphStyle first", function () {
     const div = make(`

--- a/test/ops.js
+++ b/test/ops.js
@@ -60,4 +60,60 @@ describe("morphing operations", function () {
       ],
     );
   });
+
+  it("Show findSoftMatch aborting on two future soft matches", function () {
+    // when nodes can't be softMatched because they have different types it will scan ahead
+    // but it aborts the scan ahead if it finds two nodes ahead in both the new and old content
+    // that softmatch so it can just insert the mis matched node it is on and get to the matching.
+    assertOps(
+      "<section><h1></h1><h2></h2><div></div></section>",
+      "<section><div>Alert</div><h1></h1><h2></h2><div></div></section>",
+      [
+        [
+          "Morphed",
+          "<section><h1></h1><h2></h2><div></div></section>",
+          "<section><div>Alert</div><h1></h1><h2></h2><div></div></section>",
+        ],
+        ["Added", "<div>Alert</div>"],
+        ["Morphed", "<h1></h1>", "<h1></h1>"],
+        ["Morphed", "<h2></h2>", "<h2></h2>"],
+        ["Morphed", "<div></div>", "<div></div>"],
+      ],
+    );
+  });
+
+  it("findIdSetMatch rejects morphing node that would lose more IDs", function () {
+    // here the findIdSetMatch function when it finds a node with id's it will track how many
+    // id matches in this node and then as it searches for a matching node it will track
+    // how many id's in the content it would have to remove before it finds a match
+    // if it finds more ids are going to match in-between nodes it aborts matching to
+    // allow better matching with less dom updates.
+    assertOps(
+      `<div>` +
+        `<label>1</label><input id="first">` +
+        `<label>2</label><input id="second">` +
+        `<label>3</label><input id="third">` +
+        `</div>`,
+
+      `<div>` +
+        `<label>3</label><input id="third">` +
+        `<label>1</label><input id="first">` +
+        `<label>2</label><input id="second">` +
+        `</div>`,
+      [
+        [
+          "Morphed",
+          '<div><label>1</label><input id="first"><label>2</label><input id="second"><label>3</label><input id="third"></div>',
+          '<div><label>3</label><input id="third"><label>1</label><input id="first"><label>2</label><input id="second"></div>',
+        ],
+        ["Morphed", "<label>1</label>", "<label>3</label>"],
+        ["Morphed", '<input id="third">', '<input id="third">'],
+        ["Added", "<label>1</label>"],
+        ["Morphed", '<input id="first">', '<input id="first">'],
+        ["Morphed", "<label>2</label>", "<label>2</label>"],
+        ["Morphed", '<input id="second">', '<input id="second">'],
+        ["Removed", "<label>3</label>"],
+      ],
+    );
+  });  
 });

--- a/test/preserve-focus.js
+++ b/test/preserve-focus.js
@@ -232,13 +232,6 @@ describe("Preserves focus where possible", function () {
       "b",
       false,
     );
-    if (hasMoveBefore()) {
-      assertFocus("focused");
-      // TODO moveBefore loses selection on Chrome 131.0.6778.264
-      // expect will be fixed in future release
-      // assertFocusAndSelection("focused", "b");
-    } else {
-      assertNoFocus();
-    }
+    assertFocus("focused");
   });
 });


### PR DESCRIPTION
Found we can easily add back in the old matching behavior we have lost in all the refactoring quite easily. This fixes some of my tests and improves one of the focus tests as well.  Was easy to wrap it around the new core matching checking so it now handles all the edge cases I can find really well.