### PR TITLE
Ignore value feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Idiomorph supports the following options:
 | `morphStyle`        | The style of morphing to use, either `innerHTML` or `outerHTML`                                             | `Idiomorph.morph(..., {morphStyle:'innerHTML'})`                         |
 | `ignoreActive`      | If set to `true`, idiomorph will skip the active element                                                    | `Idiomorph.morph(..., {ignoreActive:true})`                              |
 | `ignoreActiveValue` | If set to `true`, idiomorph will not update the active element's value                                      | `Idiomorph.morph(..., {ignoreActiveValue:true})`                         |
+| `ignoreValue`       | If set to `true`, idiomorph will not update any element's value including inputs, checkboxes and textarea   | `Idiomorph.morph(..., {ignoreValue:true})`                               |
 | `restoreFocus`      | If set to `true`, idiomorph will attempt to restore any lost focus and selection state after the morph.     | `Idiomorph.morph(..., {restoreFocus:true})`                              |
 | `head`              | Allows you to control how the `head` tag is merged.  See the [head](#the-head-tag) section for more details | `Idiomorph.morph(..., {head:{style:merge}})`                             |
 | `callbacks`         | Allows you to insert callbacks when events occur in the morph life cycle, see the callback table below      | `Idiomorph.morph(..., {callbacks:{beforeNodeAdded:function(node){...}})` |

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -400,11 +400,11 @@ var Idiomorph = (function () {
             if (softMatch === null) {
               // the current soft match will hard match something else in the future, leave it
               if (!ctx.idMap.has(cursor)) {
-                  // save this as the fallback if we get through the loop without finding a hard match
-                  softMatch = cursor;
-                }
+                // save this as the fallback if we get through the loop without finding a hard match
+                softMatch = cursor;
               }
             }
+          }
           if (
             softMatch === null &&
             nextSibling &&

--- a/test/core.js
+++ b/test/core.js
@@ -366,6 +366,51 @@ describe("Core morphing tests", function () {
     document.body.removeChild(parent);
   });
 
+  it("ignore input value change when ignoreValue is true", function () {
+    let parent = make("<div><input value='foo'></div>");
+    document.body.append(parent);
+
+    let initial = parent.querySelector("input");
+
+    // morph
+    let finalSrc = '<input value="bar">';
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal('<input value="bar">');
+
+    document.activeElement.should.equal(document.body);
+
+    let finalSrc2 = '<input class="foo" value="doh">';
+    Idiomorph.morph(initial, finalSrc2, {
+      morphStyle: "outerHTML",
+      ignoreValue: true,
+    });
+    initial.value.should.equal("bar");
+    initial.classList.value.should.equal("foo");
+
+    document.body.removeChild(parent);
+  });
+
+  it("ignores textarea value when ignoreValue is true", function () {
+    let parent = make("<div><textarea>foo</textarea></div>");
+    document.body.append(parent);
+    let initial = parent.querySelector("textarea");
+
+    let finalSrc = "<textarea>bar</textarea>";
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal("<textarea>bar</textarea>");
+
+    document.activeElement.should.equal(document.body);
+
+    let finalSrc2 = '<textarea class="foo">doh</textarea>';
+    Idiomorph.morph(initial, finalSrc2, {
+      morphStyle: "outerHTML",
+      ignoreValue: true,
+    });
+    initial.outerHTML.should.equal('<textarea class="foo">bar</textarea>');
+
+    document.body.removeChild(parent);
+  });
+
   it("can morph input value properly because value property is special and doesnt reflect", function () {
     let initial = make('<div><input value="foo"></div>');
     let final = make('<input value="foo">');
@@ -416,6 +461,70 @@ describe("Core morphing tests", function () {
     Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML" });
     initial.outerHTML.should.equal('<input type="checkbox" checked="">');
     initial.checked.should.equal(true);
+    document.body.removeChild(parent);
+  });
+
+  it("morph does not remove input checked with ignoreValue set", function () {
+    let parent = make('<div><input type="checkbox"></div>');
+    document.body.append(parent);
+    let initial = parent.querySelector("input");
+    initial.checked = true;
+
+    let finalSrc = '<input type="checkbox">';
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML", ignoreValue: true });
+    initial.outerHTML.should.equal('<input type="checkbox">');
+    initial.checked.should.equal(true);
+    document.body.removeChild(parent);
+  });
+
+  it("morph does not reset input checked with ignoreValue set", function () {
+    let parent = make('<div><input type="checkbox" checked></div>');
+    document.body.append(parent);
+    let initial = parent.querySelector("input");
+    initial.checked = false;
+
+    let finalSrc = '<input type="checkbox" checked>';
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML", ignoreValue: true });
+    initial.outerHTML.should.equal('<input type="checkbox" checked="">');
+    initial.checked.should.equal(false);
+    document.body.removeChild(parent);
+  });
+
+  it("morph does still set input checked when checked attribute added even with ignoreValue set", function () {
+    let parent = make('<div><input type="checkbox" checked></div>');
+    document.body.append(parent);
+    let initial = parent.querySelector("input");
+
+    let MiddleSrc = '<input type="checkbox">';
+    Idiomorph.morph(initial, MiddleSrc, { morphStyle: "outerHTML"});
+
+    initial.outerHTML.should.equal('<input type="checkbox">');
+    initial.checked.should.equal(false);
+
+    let finalSrc = '<input type="checkbox" checked>';
+
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML", ignoreValue: true});
+    initial.outerHTML.should.equal('<input type="checkbox" checked="">');
+    initial.checked.should.equal(true);
+    document.body.removeChild(parent);
+  });
+
+  it("morph does still remove input checked when checked attribute removed even with ignoreValue set", function () {
+    let parent = make('<div><input type="checkbox"></div>');
+    document.body.append(parent);
+    let initial = parent.querySelector("input");
+
+    let MiddleSrc = '<input type="checkbox" checked>';
+    Idiomorph.morph(initial, MiddleSrc, { morphStyle: "outerHTML"});
+
+    initial.outerHTML.should.equal('<input type="checkbox" checked="">');
+    initial.checked.should.equal(true);
+
+    let finalSrc = '<input type="checkbox">';
+
+    Idiomorph.morph(initial, finalSrc, { morphStyle: "outerHTML", ignoreValue: true});
+    initial.outerHTML.should.equal('<input type="checkbox">');
+    initial.checked.should.equal(false);
     document.body.removeChild(parent);
   });
 


### PR DESCRIPTION
Here is a possible new feature we can add.  We already have support to ignore the value of the active element.  This existing feature allow you to morph say a form with inputs to a new state but it will not update the contents of the item the user is currently focused on and entering input into.  However for all other inputs in the same form their current values will need to passed back to the server and returned as they are in the response that gets morphed in so that the state of the other inputs can be preserved.  This probably works well for most cases.  But it would also be nice to support a more generic value preserving option like this IgnoreValue option where instead it can preserve ALL inputs, checkboxes and textarea's with the current DOM entry state.  I found this feature mainly useful when testing form replacement and mutations on the client side as I didn't have a server interaction to submit and recreate the input values. I do not know if there is wider demand for this feature outside of this so feel free to ignore and close this PR