### PR TITLE
fix remove hook during pantry storage

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -519,6 +519,26 @@ var Idiomorph = (function () {
     }
 
     /**
+     * @param {Node | null} node - node being removed from consideration
+     * @param {string} id - The ID of the element to be moved.
+     * @param {MorphContext} ctx
+     */
+    function removeIdFromMap(node, id, ctx) {
+      while (node) {
+        let idSet = ctx.idMap.get(node);
+        if(idSet) {
+          idSet?.delete(id);
+          if (idSet.size == 0) {
+            ctx.idMap.delete(node)
+          } else {
+            ctx.idMap.set(node,idSet);
+          }
+        }
+        node = node.parentNode;
+      }
+    }
+
+    /**
      * Search for an element by id within the document and pantry, and move it using moveBefore.
      *
      * @param {Element} parentNode - The parent node to which the element will be moved.
@@ -535,6 +555,8 @@ var Idiomorph = (function () {
           ctx.target.querySelector(`#${id}`) ||
             ctx.pantry.querySelector(`#${id}`)
         );
+      // prevent this now relocated id from triggering pantry storage on remove
+      removeIdFromMap(target, id, ctx);
       moveBefore(parentNode, target, after);
       return target;
     }

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -121,6 +121,16 @@ describe("lifecycle hooks", function () {
     initial.outerHTML.should.equal("<ul><li>A</li><li>B</li></ul>");
   });
 
+  it("returning false to beforeNodeRemoved prevents removing the node with removed elemnt next to relocated id element", function () {
+    let initial = make(`<div><div><a id="a">A</a></div><div><b id="b">B</b><input type="checkbox" data-preserve-me="true" id="preserve-me"></div></div>`);
+    Idiomorph.morph(initial, `<div><div><a id="a">A</a><b id="b">B</b></div></div>`, {
+      callbacks: {
+        beforeNodeRemoved: (node) => false,
+      },
+    });
+    initial.outerHTML.should.equal(`<div><div><a id="a">A</a><b id="b">B</b></div><div><input type="checkbox" data-preserve-me="true" id="preserve-me"></div></div>`);
+  });
+
   it("returning false to beforeNodeRemoved prevents removing the node with different tag types", function () {
     let initial = make("<div><a>A</a><b>B</b><c>C</c></div>");
     Idiomorph.morph(initial, "<div><b>B</b></div>", {


### PR DESCRIPTION
When we remove a node that contains preservable id's the node is placed in the pantry to be reused later.  However if there are also nodes that we want to preserve with a before remove hook then these will now fail to be preserved as we expect because they will now be in the pantry in error.  To avoid this issue we can remove ids from idMap consideration once the id'ed element has been moved out by moveBeforeById.  This means the remaining content will then not have any preservable id's left in it when it gets eventually processed and removed and then the before remove hook will fire correctly and not remove the preserved node as expected.