### PR TITLE
support full extended swap styles in htmx oob swaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ The Idiomorph extension for htmx supports three different syntaxes for specifyin
 * `hx-swap='morph'` - This will perform a morph on the outerHTML of the target
 * `hx-swap='morph:outerHTML'` - This will perform a morph on the outerHTML of the target (explicit)
 * `hx-swap='morph:innerHTML'` - This will perform a morph on the innerHTML of the target (i.e. the children)
+* `hx-swap='innerMorph'` - This will perform a morph on the innerHTML and is useful for oob swaps where `:` is a seperator
 * `hx-swap='morph:<expr>'` - In this form, `<expr>` can be any valid JavaScript expression.  The results of the expression
    will be passed into the `Idiomorph.morph()` method as the configuration.
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@ The Idiomorph extension for htmx supports three different syntaxes for specifyin
 * `hx-swap='morph'` - This will perform a morph on the outerHTML of the target
 * `hx-swap='morph:outerHTML'` - This will perform a morph on the outerHTML of the target (explicit)
 * `hx-swap='morph:innerHTML'` - This will perform a morph on the innerHTML of the target (i.e. the children)
-* `hx-swap='innerMorph'` - This will perform a morph on the innerHTML and is useful for oob swaps where `:` is a seperator
 * `hx-swap='morph:<expr>'` - In this form, `<expr>` can be any valid JavaScript expression.  The results of the expression
    will be passed into the `Idiomorph.morph()` method as the configuration.
 
@@ -211,6 +210,14 @@ the input value in a given morph, you could use the following swap specification
           hx-target="closest form">
       Morph The Closest Form But Ignore The Active Input Value
   </button>
+```
+
+When using `hx-swap-oob` the `:` character is already used as a seperator so to support this replace it with `;;` like:
+
+```html
+  <div hx-swap-oob="morph;;{morphStyle;;'innerHTML'}:#div">
+      Morph with inner swap style 
+  </div>
 ```
 
 ## Performance

--- a/src/idiomorph-htmx.js
+++ b/src/idiomorph-htmx.js
@@ -1,11 +1,14 @@
 (function () {
   function createMorphConfig(swapStyle) {
-    if (swapStyle === "morph" || swapStyle === "morph:outerHTML") {
-      return { morphStyle: "outerHTML" };
-    } else if (swapStyle === "innerMorph" || swapStyle === "morph:innerHTML") {
-      return { morphStyle: "innerHTML" };
-    } else if (swapStyle.startsWith("morph:")) {
-      return Function("return (" + swapStyle.slice(6) + ")")();
+    if (swapStyle.startsWith("morph")) {
+      swapStyle = swapStyle.replaceAll(';;',':').slice(5);
+      if (swapStyle === "" || swapStyle === ":outerHTML") {
+        return { morphStyle: "outerHTML" };
+      } else if (swapStyle === ":innerHTML") {
+        return { morphStyle: "innerHTML" };
+      } else if (swapStyle.startsWith(":")) {
+        return Function("return (" + swapStyle.slice(1) + ")")();
+      }
     }
   }
 

--- a/src/idiomorph-htmx.js
+++ b/src/idiomorph-htmx.js
@@ -2,7 +2,7 @@
   function createMorphConfig(swapStyle) {
     if (swapStyle === "morph" || swapStyle === "morph:outerHTML") {
       return { morphStyle: "outerHTML" };
-    } else if (swapStyle === "morph:innerHTML") {
+    } else if (swapStyle === "innerMorph" || swapStyle === "morph:innerHTML") {
       return { morphStyle: "innerHTML" };
     } else if (swapStyle.startsWith("morph:")) {
       return Function("return (" + swapStyle.slice(6) + ")")();

--- a/test/htmx-integration.js
+++ b/test/htmx-integration.js
@@ -165,12 +165,11 @@ describe("Tests for the htmx integration", function () {
     initialBtn.innerHTML.should.equal("Bar");
   });
 
-  /* Currently unable to test innerHTML style oob swaps because oob-swap syntax uses a : which conflicts with morph:innerHTML
   it("keeps the element stable in an inner morph with oob-swap", function () {
     this.server.respondWith(
       "GET",
       "/test",
-      "<div id='d1' hx-swap-oob='morph:innerHTML'><button id='b1'>Bar</button></button>",
+      "<div id='d1' hx-swap-oob='innerMorph'><button id='b1'>Bar</button></button>",
     );
     let div = makeForHtmxTest(
       "<div id='d1' hx-get='/test' hx-swap='none'><button id='b1'>Foo</button></div>",
@@ -182,5 +181,4 @@ describe("Tests for the htmx integration", function () {
     initialBtn.should.equal(newBtn);
     initialBtn.innerHTML.should.equal("Bar");
   });
-  */
 });

--- a/test/htmx-integration.js
+++ b/test/htmx-integration.js
@@ -169,7 +169,24 @@ describe("Tests for the htmx integration", function () {
     this.server.respondWith(
       "GET",
       "/test",
-      "<div id='d1' hx-swap-oob='innerMorph'><button id='b1'>Bar</button></button>",
+      "<div id='d1' hx-swap-oob='morph;;innerHTML'><button id='b1'>Bar</button></button>",
+    );
+    let div = makeForHtmxTest(
+      "<div id='d1' hx-get='/test' hx-swap='none'><button id='b1'>Foo</button></div>",
+    );
+    let initialBtn = document.getElementById("b1");
+    div.click();
+    this.server.respond();
+    let newBtn = document.getElementById("b1");
+    initialBtn.should.equal(newBtn);
+    initialBtn.innerHTML.should.equal("Bar");
+  });
+
+  it("keeps the element stable in an inner morph with oob-swap w/ long syntax", function () {
+    this.server.respondWith(
+      "GET",
+      "/test",
+      "<div id='d1' hx-swap-oob='morph;;{morphStyle;;\"innerHTML\"}'><button id='b1'>Bar</button></button>",
     );
     let div = makeForHtmxTest(
       "<div id='d1' hx-get='/test' hx-swap='none'><button id='b1'>Foo</button></div>",


### PR DESCRIPTION
Currently oob swaps in htmx are not supported with idiomorph if you want to do a inner style morph as they include a : which is a seperator in hx-swap-oob. So to support this i've allowed : to be replaced with ;; in the swap style so it can also be used for supporting extended config inside the swap style as well.

For example here is a now supported extended swap with hx-swap-oob:
```html
<div hx-swap-oob="morph;;{morphStyle;;'innerHTML'}:#div">
```