### PR TITLE
Add back old BestMatch routine

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -403,7 +403,7 @@ var Idiomorph = (function () {
         }
 
         let softMatch = null;
-        let nextSibling = node.nextSibling; 
+        let nextSibling = node.nextSibling;
         let siblingSoftMatchCount = 0;
         let displaceMatchCount = 0;
 
@@ -449,7 +449,7 @@ var Idiomorph = (function () {
             // increment the count of future soft matches
             siblingSoftMatchCount++;
             nextSibling = nextSibling.nextSibling;
-    
+
             // If there are two future soft matches, block soft matching for this node to allow
             // future siblings to soft match. This is to reduce churn in the DOM when an element
             // is prepended.

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -384,9 +384,9 @@ var Idiomorph = (function () {
         let softMatch = null;
         let nextSibling = node.nextSibling;
         let siblingSoftMatchCount = 0;
-        let discardMatchCount = 0;
+        let displaceMatchCount = 0;
 
-        // max id matches we are willing to discard in our search
+        // max id matches we are willing to displace in our search
         const nodeMatchCount = ctx.idMap.get(node)?.size || 0;
 
         let cursor = startPoint;
@@ -411,10 +411,10 @@ var Idiomorph = (function () {
               }
             }
           }
-          // check for ids we may be discarding when matching
-          discardMatchCount += ctx.idMap.get(cursor)?.size || 0;
-          if (discardMatchCount > nodeMatchCount) {
-            // if we are going to discard more ids than the node contains then
+          // check for ids we may be displaced when matching
+          displaceMatchCount += ctx.idMap.get(cursor)?.size || 0;
+          if (displaceMatchCount > nodeMatchCount) {
+            // if we are going to displace more ids than the node contains then
             // we do not have a good candidate for an id match, so return
             break;
           }

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -382,7 +382,7 @@ var Idiomorph = (function () {
        */
       function findBestMatch(ctx, node, startPoint, endPoint) {
         let softMatch = null;
-        let nextSibling = node.nextSibling; 
+        let nextSibling = node.nextSibling;
         let siblingSoftMatchCount = 0;
         let discardMatchCount = 0;
 
@@ -402,7 +402,7 @@ var Idiomorph = (function () {
               // the current soft match will hard match something else in the future, leave it
               if (!ctx.idMap.has(cursor)) {
                 // optimization: if node can't id set match, we can just return the soft match immediately
-                if (!ctx.idMap.has(node)) {
+                if (!nodeMatchCount) {
                   return cursor;
                 } else {
                   // save this as the fallback if we get through the loop without finding a hard match
@@ -428,7 +428,7 @@ var Idiomorph = (function () {
             // increment the count of future soft matches
             siblingSoftMatchCount++;
             nextSibling = nextSibling.nextSibling;
-    
+
             // If there are two future soft matches, block soft matching for this node to allow
             // future siblings to soft match. This is to reduce churn in the DOM when an element
             // is prepended.

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -121,6 +121,16 @@ describe("lifecycle hooks", function () {
     initial.outerHTML.should.equal("<ul><li>A</li><li>B</li></ul>");
   });
 
+  it("returning false to beforeNodeRemoved prevents removing the node with removed elemnt next to relocated id element", function () {
+    let initial = make(`<div><div><a id="a">A</a></div><div><b id="b">B</b><input type="checkbox" data-preserve-me="true" id="preserve-me"></div></div>`);
+    Idiomorph.morph(initial, `<div><div><a id="a">A</a><b id="b">B</b></div></div>`, {
+      callbacks: {
+        beforeNodeRemoved: (node) => false,
+      },
+    });
+    initial.outerHTML.should.equal(`<div><div><a id="a">A</a><b id="b">B</b></div><div><input type="checkbox" data-preserve-me="true" id="preserve-me"></div></div>`);
+  });
+
   it("returning false to beforeNodeRemoved prevents removing the node with different tag types", function () {
     let initial = make("<div><a>A</a><b>B</b><c>C</c></div>");
     Idiomorph.morph(initial, "<div><b>B</b></div>", {

--- a/test/lib/utilities.js
+++ b/test/lib/utilities.js
@@ -90,7 +90,7 @@ function assertNoFocus() {
   document.activeElement.tagName.should.eql("BODY");
 }
 
-function assertOps(before, after, expectedOps) {
+function assertOps(before, after, expectedOps, singleNode = true) {
   let ops = [];
   let initial = make(before);
   let final = make(after);
@@ -121,7 +121,7 @@ function assertOps(before, after, expectedOps) {
     console.log('test failing Operations is:');
     console.log(ops);
   }
-  initial.outerHTML.should.equal(finalCopy.outerHTML);
+  if(singleNode) initial.outerHTML.should.equal(finalCopy.outerHTML);
   ops.should.eql(expectedOps);
 }
 

--- a/test/ops.js
+++ b/test/ops.js
@@ -222,5 +222,165 @@ describe("morphing operations", function () {
         ["Removed", "<label>3</label>"],
       ],
     );
-  });  
+  });
+
+  it("show bestMatch routine can match the best old node for morphing", function () {
+    // the findBestMatch can detect when there is a single node with id's remaining and instead
+    // of matching the first node it will instead find the node with the most mathing id's so
+    // it can retain the most state possible by displacing the least nodes with id's and their siblings.
+    assertOps(
+      `<div>`+
+        `<input type="text" id="first">`+
+        `<p>i will get lost</p>`+
+        `<input type="text" id="second">`+
+        `<p>i will get saved</p>`+
+        `<input type="text" id="third">`+
+        `<p>i will get saved</p>`+
+      `</div>`,
+
+      `<div>`+
+        `<input type="text" id="first">`+
+        `<p>i will get lost</p>`+
+      `</div>`+
+      `<div>`+  
+        `<input type="text" id="second">`+
+        `<p>i will get saved</p>`+
+        `<input type="text" id="third">`+
+        `<p>i will get saved</p>`+
+      `</div>`,
+      [
+        [
+          'Added',
+          '<div><input type="text" id="first"><p>i will get lost</p></div>'
+        ],
+        [
+          'Morphed',
+          '<div></div>',
+          '<div><input type="text" id="first"><p>i will get lost</p></div>'
+        ],
+        [
+          'Morphed',
+          '<input type="text" id="first">',
+          '<input type="text" id="first">'
+        ],
+        [ 'Added', '<p>i will get lost</p>' ],
+        [
+          'Morphed',
+          '<div><p>i will get lost</p><input type="text" id="second"><p>i will get saved</p><input type="text" id="third"><p>i will get saved</p></div>',        
+          '<div><input type="text" id="second"><p>i will get saved</p><input type="text" id="third"><p>i will get saved</p></div>'
+        ],
+        [ 'Removed', '<p>i will get lost</p>' ],
+        [
+          'Morphed',
+          '<input type="text" id="second">',
+          '<input type="text" id="second">'
+        ],
+        [ 'Morphed', '<p>i will get saved</p>', '<p>i will get saved</p>' ],
+        [
+          'Morphed',
+          '<input type="text" id="third">',
+          '<input type="text" id="third">'
+        ],
+        [ 'Morphed', '<p>i will get saved</p>', '<p>i will get saved</p>' ]
+      ],
+      false,
+    );
+  });
+
+  it("show bestMatch routine can match the best old node for morphing with deeper content", function () {
+    // the new bestMatch also handles checking on inner children scans for the best last node with ids
+    // to match with while before it was only run on the top node
+    assertOps(
+      `<div>`+
+        `<div>`+
+          `<input type="text" id="first">`+
+          `<p>i will get lost</p>`+
+          `<input type="text" id="second">`+
+          `<p>i will get saved</p>`+
+          `<input type="text" id="third">`+
+          `<p>i will get saved</p>`+
+        `</div>`+
+      `</div>`,
+
+      `<div>`+
+        `<div>`+
+          `<input type="text" id="first">`+
+          `<p>i will get lost</p>`+
+        `</div>`+
+        `<div>`+  
+          `<input type="text" id="second">`+
+          `<p>i will get saved</p>`+
+          `<input type="text" id="third">`+
+          `<p>i will get saved</p>`+
+        `</div>`+
+      `</div>`,
+      [
+        [
+          'Morphed',
+          '<div><div><input type="text" id="first"><p>i will get lost</p><input type="text" id="second"><p>i will get saved</p><input type="text" id="third"><p>i will get saved</p></div></div>',
+          '<div><div><input type="text" id="first"><p>i will get lost</p></div><div><input type="text" id="second"><p>i will get saved</p><input type="text" id="third"><p>i will get saved</p></div></div>'
+        ],
+        [
+          'Added',
+          '<div><input type="text" id="first"><p>i will get lost</p></div>'
+        ],
+        [
+          'Morphed',
+          '<div></div>',
+          '<div><input type="text" id="first"><p>i will get lost</p></div>'
+        ],
+        [
+          'Morphed',
+          '<input type="text" id="first">',
+          '<input type="text" id="first">'
+        ],
+        [ 'Added', '<p>i will get lost</p>' ],
+        [
+          'Morphed',
+          '<div><p>i will get lost</p><input type="text" id="second"><p>i will get saved</p><input type="text" id="third"><p>i will get saved</p></div>',        
+          '<div><input type="text" id="second"><p>i will get saved</p><input type="text" id="third"><p>i will get saved</p></div>'
+        ],
+        [ 'Removed', '<p>i will get lost</p>' ],
+        [
+          'Morphed',
+          '<input type="text" id="second">',
+          '<input type="text" id="second">'
+        ],
+        [ 'Morphed', '<p>i will get saved</p>', '<p>i will get saved</p>' ],
+        [
+          'Morphed',
+          '<input type="text" id="third">',
+          '<input type="text" id="third">'
+        ],
+        [ 'Morphed', '<p>i will get saved</p>', '<p>i will get saved</p>' ]
+      ],
+    );
+  });
+
+  it("show bestMatch routine can match the best old node for morphing and adding dummy div before", function () {
+    assertOps(
+      `<div>`+
+        `<input type="text" id="focus">`+
+      `</div>`,
+
+      `<div></div>`+
+        `<div>`+
+        `<input type="text" id="focus">`+  
+      `</div>`,
+      [
+        [ 'Added', '<div></div>' ],
+        [
+          'Morphed',
+          '<div><input type="text" id="focus"></div>',
+          '<div><input type="text" id="focus"></div>'
+        ],
+        [
+          'Morphed',
+          '<input type="text" id="focus">',
+          '<input type="text" id="focus">'
+        ]
+      ],
+      false,
+    );
+  });
 });

--- a/test/ops.js
+++ b/test/ops.js
@@ -188,4 +188,39 @@ describe("morphing operations", function () {
       ],
     );
   });
+
+  it("findBestMatch rejects morphing node that would lose more IDs", function () {
+    // here the findBestMatch function when it finds a node with id's it will track how many
+    // id matches in this node and then as it searches for a matching node it will track
+    // how many id's in the content it would have to remove before it finds a match
+    // if it finds more ids are going to match in-between nodes it aborts matching to
+    // allow better matching with less dom updates.
+    assertOps(
+      `<div>` +
+        `<label>1</label><input id="first">` +
+        `<label>2</label><input id="second">` +
+        `<label>3</label><input id="third">` +
+        `</div>`,
+
+      `<div>` +
+        `<label>3</label><input id="third">` +
+        `<label>1</label><input id="first">` +
+        `<label>2</label><input id="second">` +
+        `</div>`,
+      [
+        [
+          "Morphed",
+          '<div><label>1</label><input id="first"><label>2</label><input id="second"><label>3</label><input id="third"></div>',
+          '<div><label>3</label><input id="third"><label>1</label><input id="first"><label>2</label><input id="second"></div>',
+        ],
+        ["Morphed", "<label>1</label>", "<label>3</label>"],
+        ["Morphed", '<input id="third">', '<input id="third">'],
+        ["Added", "<label>1</label>"],
+        ["Morphed", '<input id="first">', '<input id="first">'],
+        ["Morphed", "<label>2</label>", "<label>2</label>"],
+        ["Morphed", '<input id="second">', '<input id="second">'],
+        ["Removed", "<label>3</label>"],
+      ],
+    );
+  });  
 });

--- a/test/preserve-focus.js
+++ b/test/preserve-focus.js
@@ -232,13 +232,7 @@ describe("Preserves focus where possible", function () {
       "b",
       false,
     );
-    if (hasMoveBefore()) {
-      assertFocus("focused");
-      // TODO moveBefore loses selection on Chrome 131.0.6778.264
-      // expect will be fixed in future release
-      // assertFocusAndSelection("focused", "b");
-    } else {
-      assertNoFocus();
-    }
+
+    assertFocus("focused");
   });
 });


### PR DESCRIPTION
https://codepen.io/MichaelWest22/pen/yyBwPww
https://codepen.io/MichaelWest22/pen/XJrGzxv

In the old idiomorph there is extra bestMatch code that handles outerHTML swaps.  It handles the situation where you are replacing a single node with possibly multiple nodes via the outerHTML morph mode and it find the most id'ed node and swaps that with the single node.  This works because we know there is just one node in the old content so finding the best match for a single node is a simple routine.  When trying to integrate this with the new Algorithm I found that it was possible to make this feature more generic.  By finding the last node in the old child nodes that has id content at each tree level we can apply the original bestMatch checking just to this last node with id's.  It may be possible to do this same kind of logic every time but it would get far to complex and slow so instead we can apply it just to the last node with id's.  We know this node is the last one we care about so can then check all remaining new nodes for the very best match easily.  To do this we just scan for the last id with node at the start of the morphChildren loop and apply an extra check at the start of findBestMatch which will cause it to insert new child nodes that are not the best match till the best match shows up.  

Added some tests to show off where it applies and also the above two codepen's show off how it works but this feature only covers off what is kind of an edge case and will often not be needed outside of these edge cases.