### PR TITLE
Bugfix: insertionPoint can become incorrect after morphNode and createNode

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -323,11 +323,21 @@ var Idiomorph = (function () {
             ctx,
           );
           morphNode(movedChild, newChild, ctx);
+          insertionPoint = movedChild.nextSibling;
           continue;
         }
 
         // last resort: insert the new node from scratch
-        createNode(oldParent, newChild, insertionPoint, ctx);
+        const insertedNode = createNode(
+          oldParent,
+          newChild,
+          insertionPoint,
+          ctx,
+        );
+        // could be null if beforeNodeAdded prevented insertion
+        if (insertedNode) {
+          insertionPoint = insertedNode.nextSibling;
+        }
       }
 
       // remove any remaining old nodes that didn't match up with new content

--- a/test/fidelity.js
+++ b/test/fidelity.js
@@ -88,6 +88,26 @@ describe("Tests to ensure that idiomorph merges properly", function () {
     );
   });
 
+  it("move id node into div does not break insertion point", function () {
+    // bug: https://github.com/bigskysoftware/idiomorph/pull/99
+    // when moving an IDed element into an inner div, moveBeforeById can
+    // move the parent's insertionPoint node, causing an incorrect morph result
+    testFidelity(
+      `<div><input id="first"></div>`,
+      `<div><div><input id="first"></div></div>`,
+    );
+  });
+
+  it("move id node into div that has been restored from pantry does not break insertion point", function () {
+    // bug: https://github.com/bigskysoftware/idiomorph/pull/99
+    // after restoring a node from the pantry, if its next sibling gets moved into it
+    // via moveBeforeById, thats the current insertionPoint, thus an incorrect morph
+    testFidelity(
+      `<div><a id="a"></a><br><b id="b"></b></div>`,
+      `<div><br><a id="a"><b id="b"></b></a></div>`,
+    );
+  });
+
   it("issue https://github.com/bigskysoftware/idiomorph/issues/11", function () {
     let el1 = make('<fieldset id="el"></fieldset>');
 


### PR DESCRIPTION
Redux of https://github.com/bigskysoftware/idiomorph/pull/99

This is a very subtle bug! Let's say we perform the following morph, wrapping an IDed node in a `<p>`:
`<div><a id="a"></div>` => `<div><p><a id="a"></p></div>`

When the `<p>` is created, `insertionPoint` points to `#a`. We then descend into the new `<p>` and use `moveBeforeById` to pull the `#a` into it, preserving its identity. However, when we then ascend back out into the parent `<div>` and continue the morph, `insertionPoint` still points to `#a`, which is all wrong. This can also happen in a different branch in a more convoluted scenario. 

To address this issue, we simply reset the `insertionPoint` after each mutating operation.

Big props to @MichaelWest22 for discovering this and coming up with a solution.