### PR TITLE
Flip the `restoreFocus` option to default to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   * Remove `beforeNodePantried` callback option. This addition in v0.4.0 was an unfortunate necessity of the old `twoPass` mode, but is no longer needed with the new algorithm. (@botandrose)
 
 * Added:
-  * New `restoreFocus` option. On older browsers, moving the focused element (or one of its parents) can result in loss of focus and selection state. This option will restore this state for IDed elements, at the cost of firing extra `focus` and `selection` events. (@botandrose)
+  * New on-by-default `restoreFocus` option. On older browsers, moving the focused element (or one of its parents) can result in loss of focus and selection state. This option restores this state for IDed elements, at the cost of firing extra `focus` and `selection` events. (@botandrose)
 
 * Fixed:
   * Boolean attributes are now correctly set to `""` instead of `"true"`. https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML (@MichaelWest22)

--- a/README.md
+++ b/README.md
@@ -89,29 +89,29 @@ This will replace the _inner_ content of the existing node with the new content.
 
 Idiomorph supports the following options:
 
-| option              | meaning                                                                                                     | example                                                                  |
-|---------------------|-------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
-| `morphStyle`        | The style of morphing to use, either `innerHTML` or `outerHTML`                                             | `Idiomorph.morph(..., {morphStyle:'innerHTML'})`                         |
-| `ignoreActive`      | If set to `true`, idiomorph will skip the active element                                                    | `Idiomorph.morph(..., {ignoreActive:true})`                              |
-| `ignoreActiveValue` | If set to `true`, idiomorph will not update the active element's value                                      | `Idiomorph.morph(..., {ignoreActiveValue:true})`                         |
-| `restoreFocus`      | If set to `true`, idiomorph will attempt to restore any lost focus and selection state after the morph.     | `Idiomorph.morph(..., {restoreFocus:true})`                              |
-| `head`              | Allows you to control how the `head` tag is merged.  See the [head](#the-head-tag) section for more details | `Idiomorph.morph(..., {head:{style:merge}})`                             |
-| `callbacks`         | Allows you to insert callbacks when events occur in the morph life cycle, see the callback table below      | `Idiomorph.morph(..., {callbacks:{beforeNodeAdded:function(node){...}})` |
+| option (with default)         | meaning                                                                                                    | example                                                                  |
+|-------------------------------|------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| `morphStyle: 'outerHTML'`     | The style of morphing to use, either `outerHTML` or `innerHTML`                                            | `Idiomorph.morph(..., {morphStyle:'innerHTML'})`                         |
+| `ignoreActive: false`         | If `true`, idiomorph will skip the active element                                                          | `Idiomorph.morph(..., {ignoreActive:true})`                              |
+| `ignoreActiveValue: false`    | If `true`, idiomorph will not update the active element's value                                            | `Idiomorph.morph(..., {ignoreActiveValue:true})`                         |
+| `restoreFocus: true`          | If `true`, idiomorph will attempt to restore any lost focus and selection state after the morph.           | `Idiomorph.morph(..., {restoreFocus:true})`                              |
+| `head: {style: 'merge', ...}` | Allows you to control how the `head` tag is merged. See the [head](#the-head-tag) section for more details | `Idiomorph.morph(..., {head:{style:'merge'}})`                           |
+| `callbacks: {...}`            | Allows you to insert callbacks when events occur in the morph lifecycle. See the callback table below      | `Idiomorph.morph(..., {callbacks:{beforeNodeAdded:function(node){...}})` |
 
 #### Callbacks
 
 Idiomorph provides the following callbacks, which can be used to intercept and, for some callbacks, modify the swapping behavior
 of the algorithm.
 
-| callback                                                     | description                                                                                                            | return value meaning                               |
-|--------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
-| beforeNodeAdded(node)                                        | Called before a new node is added to the DOM                                                                           | return false to not add the node                   |
-| afterNodeAdded(node)                                         | Called after a new node is added to the DOM                                                                            | none                                               |
-| beforeNodeMorphed(oldNode, newNode)                          | Called before a node is morphed in the DOM                                                                             | return false to skip morphing the node             |
-| afterNodeMorphed(oldNode, newNode)                           | Called after a node is morphed in the DOM                                                                              | none                                               |
-| beforeNodeRemoved(node)                                      | Called before a node is removed from the DOM                                                                           | return false to not remove the node                |
-| afterNodeRemoved(node)                                       | Called after a node is removed from the DOM                                                                            | none                                               |
-| beforeAttributeUpdated(attributeName, node, mutationType)    | Called before an attribute on an element is updated or removed (`mutationType` is either "update" or "remove")  | return false to not update or remove the attribute |
+| callback                                                  | description                                                                                                    | return value meaning                               |
+|-----------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
+| beforeNodeAdded(node)                                     | Called before a new node is added to the DOM                                                                   | return false to not add the node                   |
+| afterNodeAdded(node)                                      | Called after a new node is added to the DOM                                                                    | none                                               |
+| beforeNodeMorphed(oldNode, newNode)                       | Called before a node is morphed in the DOM                                                                     | return false to skip morphing the node             |
+| afterNodeMorphed(oldNode, newNode)                        | Called after a node is morphed in the DOM                                                                      | none                                               |
+| beforeNodeRemoved(node)                                   | Called before a node is removed from the DOM                                                                   | return false to not remove the node                |
+| afterNodeRemoved(node)                                    | Called after a node is removed from the DOM                                                                    | none                                               |
+| beforeAttributeUpdated(attributeName, node, mutationType) | Called before an attribute on an element is updated or removed (`mutationType` is either "update" or "remove") | return false to not update or remove the attribute |
 
 ### The `head` tag
 

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -141,7 +141,7 @@ var Idiomorph = (function () {
       shouldRemove: noOp,
       afterHeadMorphed: noOp,
     },
-    restoreFocus: false,
+    restoreFocus: true,
   };
 
   /**

--- a/test/preserve-focus.js
+++ b/test/preserve-focus.js
@@ -1,4 +1,4 @@
-describe("Preserves focus where possible", function () {
+describe("Preserves focus algorithmically where possible", function () {
   setup();
 
   function assertFocusPreservation(
@@ -12,6 +12,7 @@ describe("Preserves focus where possible", function () {
     setFocusAndSelection(focusId, selection);
     Idiomorph.morph(getWorkArea(), after, {
       morphStyle: "innerHTML",
+      restoreFocus: false,
     });
     getWorkArea().innerHTML.should.equal(after);
     // for when we fall short of the ideal

--- a/test/restore-focus.js
+++ b/test/restore-focus.js
@@ -1,281 +1,589 @@
 describe("Option to forcibly restore focus after morph", function () {
   setup();
 
-  it("restores focus and selection state with and outerHTML morphStyle", function () {
-    const div = make(`
-      <div>
-        <input type="text" id="focused" value="abc">
-        <input type="text" id="other">
-      </div>
-    `);
-    getWorkArea().append(div);
-    setFocusAndSelection("focused", "b");
-
-    let finalSrc = `
-      <div>
-        <input type="text" id="other">
-        <input type="text" id="focused" value="abc">
-      </div>
-    `;
-    Idiomorph.morph(div, finalSrc, {
-      morphStyle: "outerHTML",
-      restoreFocus: true,
-    });
-
-    getWorkArea().innerHTML.should.equal(finalSrc);
-    assertFocusAndSelection("focused", "b");
-  });
-
-  it("restores focus and selection state when elements are moved to different levels of the DOM", function () {
-    getWorkArea().innerHTML = `
-      <div>
-        <input type="text" id="other">
+  describe("defaults to on", function () {
+    it("restores focus and selection state with outerHTML morphStyle", function () {
+      const div = make(`
         <div>
           <input type="text" id="focused" value="abc">
-        </div>
-      </div>
-    `;
-    setFocusAndSelection("focused", "b");
-
-    let finalSrc = `
-      <div>
-        <input type="text" id="other">
-        <input type="text" id="focused" value="abc">
-      </div>
-    `;
-    Idiomorph.morph(getWorkArea(), finalSrc, {
-      morphStyle: "innerHTML",
-      restoreFocus: true,
-    });
-
-    getWorkArea().innerHTML.should.equal(finalSrc);
-    assertFocusAndSelection("focused", "b");
-  });
-
-  it("restores focus and selection state when elements are moved between different containers", function () {
-    getWorkArea().innerHTML = `
-      <div>
-        <div id="left">
-          <input type="text" id="focused" value="abc">
-        </div>
-        <div id="right">
           <input type="text" id="other">
         </div>
-      </div>
-    `;
-    setFocusAndSelection("focused", "b");
+      `);
+      getWorkArea().append(div);
+      setFocusAndSelection("focused", "b");
 
-    let finalSrc = `
-      <div>
-        <div id="left">
+      let finalSrc = `
+        <div>
           <input type="text" id="other">
-        </div>
-        <div id="right">
           <input type="text" id="focused" value="abc">
         </div>
-      </div>
-    `;
-    Idiomorph.morph(getWorkArea(), finalSrc, {
-      morphStyle: "innerHTML",
-      restoreFocus: true,
+      `;
+      Idiomorph.morph(div, finalSrc, {
+        morphStyle: "outerHTML",
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      assertFocusAndSelection("focused", "b");
     });
 
-    getWorkArea().innerHTML.should.equal(finalSrc);
-    assertFocusAndSelection("focused", "b");
-  });
+    it("restores focus and selection state when elements are moved to different levels of the DOM", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <input type="text" id="other">
+          <div>
+            <input type="text" id="focused" value="abc">
+          </div>
+        </div>
+      `;
+      setFocusAndSelection("focused", "b");
 
-  it("restores focus and selection state when parents are reorderd", function () {
-    getWorkArea().innerHTML = `
-      <div>
-        <div id="left">
+      let finalSrc = `
+        <div>
+          <input type="text" id="other">
           <input type="text" id="focused" value="abc">
         </div>
-        <div id="right">
-          <input type="text" id="other">
-        </div>
-      </div>
-    `;
-    setFocusAndSelection("focused", "b");
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+      });
 
-    let finalSrc = `
-      <div>
-        <div id="right">
-          <input type="text" id="other">
-        </div>
-        <div id="left">
-          <input type="text" id="focused" value="abc">
-        </div>
-      </div>
-    `;
-    Idiomorph.morph(getWorkArea(), finalSrc, {
-      morphStyle: "innerHTML",
-      restoreFocus: true,
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      assertFocusAndSelection("focused", "b");
     });
 
-    getWorkArea().innerHTML.should.equal(finalSrc);
-    assertFocusAndSelection("focused", "b");
-  });
+    it("restores focus and selection state when elements are moved between different containers", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <div id="left">
+            <input type="text" id="focused" value="abc">
+          </div>
+          <div id="right">
+            <input type="text" id="other">
+          </div>
+        </div>
+      `;
+      setFocusAndSelection("focused", "b");
 
-  it("restores focus and selection state with restoreFocus option and outerHTML morphStyle", function () {
-    const div = make(`
-      <div>
-        <input type="text" id="focused" value="abc">
-        <input type="text" id="other">
-      </div>
-    `);
-    getWorkArea().append(div);
-    setFocusAndSelection("focused", "b");
+      let finalSrc = `
+        <div>
+          <div id="left">
+            <input type="text" id="other">
+          </div>
+          <div id="right">
+            <input type="text" id="focused" value="abc">
+          </div>
+        </div>
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+      });
 
-    let finalSrc = `
-      <div>
-        <input type="text" id="other">
-        <input type="text" id="focused" value="abc">
-      </div>
-    `;
-    Idiomorph.morph(div, finalSrc, {
-      morphStyle: "outerHTML",
-      restoreFocus: true,
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      assertFocusAndSelection("focused", "b");
     });
 
-    getWorkArea().innerHTML.should.equal(finalSrc);
-    assertFocusAndSelection("focused", "b");
-  });
+    it("restores focus and selection state when parents are reorderd", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <div id="left">
+            <input type="text" id="focused" value="abc">
+          </div>
+          <div id="right">
+            <input type="text" id="other">
+          </div>
+        </div>
+      `;
+      setFocusAndSelection("focused", "b");
 
-  it("restores focus and selection state with restoreFocus option when elements are moved to different levels of the DOM", function () {
-    getWorkArea().innerHTML = `
-      <div>
-        <input type="text" id="other">
+      let finalSrc = `
+        <div>
+          <div id="right">
+            <input type="text" id="other">
+          </div>
+          <div id="left">
+            <input type="text" id="focused" value="abc">
+          </div>
+        </div>
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      assertFocusAndSelection("focused", "b");
+    });
+
+    it("restores focus and selection state with outerHTML morphStyle", function () {
+      const div = make(`
         <div>
           <input type="text" id="focused" value="abc">
-        </div>
-      </div>
-    `;
-    setFocusAndSelection("focused", "b");
-
-    let finalSrc = `
-      <div>
-        <input type="text" id="other">
-        <input type="text" id="focused" value="abc">
-      </div>
-    `;
-    Idiomorph.morph(getWorkArea(), finalSrc, {
-      morphStyle: "innerHTML",
-      restoreFocus: true,
-    });
-
-    getWorkArea().innerHTML.should.equal(finalSrc);
-    assertFocusAndSelection("focused", "b");
-  });
-
-  it("restores focus and selection state with restoreFocus option when elements are moved between different containers", function () {
-    getWorkArea().innerHTML = `
-      <div>
-        <div id="left">
-          <input type="text" id="focused" value="abc">
-        </div>
-        <div id="right">
           <input type="text" id="other">
         </div>
-      </div>
-    `;
-    setFocusAndSelection("focused", "b");
+      `);
+      getWorkArea().append(div);
+      setFocusAndSelection("focused", "b");
 
-    let finalSrc = `
-      <div>
-        <div id="left">
+      let finalSrc = `
+        <div>
           <input type="text" id="other">
-        </div>
-        <div id="right">
           <input type="text" id="focused" value="abc">
         </div>
-      </div>
-    `;
-    Idiomorph.morph(getWorkArea(), finalSrc, {
-      morphStyle: "innerHTML",
-      restoreFocus: true,
+      `;
+      Idiomorph.morph(div, finalSrc, {
+        morphStyle: "outerHTML",
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      assertFocusAndSelection("focused", "b");
     });
 
-    getWorkArea().innerHTML.should.equal(finalSrc);
-    assertFocusAndSelection("focused", "b");
-  });
+    it("restores focus and selection state when elements are moved to different levels of the DOM", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <input type="text" id="other">
+          <div>
+            <input type="text" id="focused" value="abc">
+          </div>
+        </div>
+      `;
+      setFocusAndSelection("focused", "b");
 
-  it("restores focus and selection state with restoreFocus option when parents are reordered", function () {
-    getWorkArea().innerHTML = `
-      <div>
-        <div id="left">
+      let finalSrc = `
+        <div>
+          <input type="text" id="other">
           <input type="text" id="focused" value="abc">
         </div>
-        <div id="right">
-          <input type="text" id="other">
-        </div>
-      </div>
-    `;
-    setFocusAndSelection("focused", "b");
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+      });
 
-    let finalSrc = `
-      <div>
-        <div id="right">
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      assertFocusAndSelection("focused", "b");
+    });
+
+    it("restores focus and selection state when elements are moved between different containers", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <div id="left">
+            <input type="text" id="focused" value="abc">
+          </div>
+          <div id="right">
+            <input type="text" id="other">
+          </div>
+        </div>
+      `;
+      setFocusAndSelection("focused", "b");
+
+      let finalSrc = `
+        <div>
+          <div id="left">
+            <input type="text" id="other">
+          </div>
+          <div id="right">
+            <input type="text" id="focused" value="abc">
+          </div>
+        </div>
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      assertFocusAndSelection("focused", "b");
+    });
+
+    it("restores focus and selection state when parents are reordered", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <div id="left">
+            <input type="text" id="focused" value="abc">
+          </div>
+          <div id="right">
+            <input type="text" id="other">
+          </div>
+        </div>
+      `;
+      setFocusAndSelection("focused", "b");
+
+      let finalSrc = `
+        <div>
+          <div id="right">
+            <input type="text" id="other">
+          </div>
+          <div id="left">
+            <input type="text" id="focused" value="abc">
+          </div>
+        </div>
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      assertFocusAndSelection("focused", "b");
+    });
+
+    it("restores focus and selection state with a textarea", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <textarea id="focused">abc</textarea>
+          <textarea id="other"></textarea>
+        </div>
+      `;
+      setFocusAndSelection("focused", "b");
+
+      let finalSrc = `
+        <div>
+          <textarea id="other"></textarea>
+          <textarea id="focused">abc</textarea>
+        </div>
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      assertFocusAndSelection("focused", "b");
+    });
+
+    it("does nothing if a non input/textarea el is focused", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <p id="focused"></p>
+          <p id="other"></p>
+        </div>
+      `;
+      setFocus("focused");
+
+      let finalSrc = `
+        <div>
+          <p id="other"></p>
+          <p id="focused"></p>
+        </div>
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      assertNoFocus();
+    });
+  });
+
+  describe("with option off", function () {
+    it("retains focus but loses selection state with outerHTML morphStyle", function () {
+      const div = make(`
+        <div>
+          <input type="text" id="focused" value="abc">
           <input type="text" id="other">
         </div>
-        <div id="left">
+      `);
+      getWorkArea().append(div);
+      setFocusAndSelection("focused", "b");
+
+      let finalSrc = `
+        <div>
+          <input type="text" id="other">
           <input type="text" id="focused" value="abc">
         </div>
-      </div>
-    `;
-    Idiomorph.morph(getWorkArea(), finalSrc, {
-      morphStyle: "innerHTML",
-      restoreFocus: true,
+      `;
+      Idiomorph.morph(div, finalSrc, {
+        morphStyle: "outerHTML",
+        restoreFocus: false,
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      if (document.moveBefore) {
+        assertFocusAndSelection("focused", "");
+      } else {
+        assertNoFocus();
+      }
     });
 
-    getWorkArea().innerHTML.should.equal(finalSrc);
-    assertFocusAndSelection("focused", "b");
-  });
+    it("retains focus but loses selection state when elements are moved to different levels of the DOM", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <input type="text" id="other">
+          <div>
+            <input type="text" id="focused" value="abc">
+          </div>
+        </div>
+      `;
+      setFocusAndSelection("focused", "b");
 
-  it("restores focus and selection state with a textarea", function () {
-    getWorkArea().innerHTML = `
-      <div>
-        <textarea id="focused">abc</textarea>
-        <textarea id="other"></textarea>
-      </div>
-    `;
-    setFocusAndSelection("focused", "b");
+      let finalSrc = `
+        <div>
+          <input type="text" id="other">
+          <input type="text" id="focused" value="abc">
+        </div>
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+        restoreFocus: false,
+      });
 
-    let finalSrc = `
-      <div>
-        <textarea id="other"></textarea>
-        <textarea id="focused">abc</textarea>
-      </div>
-    `;
-    Idiomorph.morph(getWorkArea(), finalSrc, {
-      morphStyle: "innerHTML",
-      restoreFocus: true,
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      if (document.moveBefore) {
+        assertFocusAndSelection("focused", "");
+      } else {
+        assertNoFocus();
+      }
     });
 
-    getWorkArea().innerHTML.should.equal(finalSrc);
-    assertFocusAndSelection("focused", "b");
-  });
+    it("retains focus but loses selection state when elements are moved between different containers", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <div id="left">
+            <input type="text" id="focused" value="abc">
+          </div>
+          <div id="right">
+            <input type="text" id="other">
+          </div>
+        </div>
+      `;
+      setFocusAndSelection("focused", "b");
 
-  it("does nothing if a non input/textarea el is focused", function () {
-    getWorkArea().innerHTML = `
-      <div>
-        <p id="focused"></p>
-        <p id="other"></p>
-      </div>
-    `;
-    setFocus("focused");
+      let finalSrc = `
+        <div>
+          <div id="left">
+            <input type="text" id="other">
+          </div>
+          <div id="right">
+            <input type="text" id="focused" value="abc">
+          </div>
+        </div>
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+        restoreFocus: false,
+      });
 
-    let finalSrc = `
-      <div>
-        <p id="other"></p>
-        <p id="focused"></p>
-      </div>
-    `;
-    Idiomorph.morph(getWorkArea(), finalSrc, {
-      morphStyle: "innerHTML",
-      restoreFocus: true,
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      if (document.moveBefore) {
+        assertFocusAndSelection("focused", "");
+      } else {
+        assertNoFocus();
+      }
     });
 
-    getWorkArea().innerHTML.should.equal(finalSrc);
-    assertNoFocus();
+    it("retains focus but loses selection state when parents are reorderd", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <div id="left">
+            <input type="text" id="focused" value="abc">
+          </div>
+          <div id="right">
+            <input type="text" id="other">
+          </div>
+        </div>
+      `;
+      setFocusAndSelection("focused", "b");
+
+      let finalSrc = `
+        <div>
+          <div id="right">
+            <input type="text" id="other">
+          </div>
+          <div id="left">
+            <input type="text" id="focused" value="abc">
+          </div>
+        </div>
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+        restoreFocus: false,
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      if (document.moveBefore) {
+        assertFocusAndSelection("focused", "");
+      } else {
+        assertNoFocus();
+      }
+    });
+
+    it("retains focus but loses selection state with outerHTML morphStyle", function () {
+      const div = make(`
+        <div>
+          <input type="text" id="focused" value="abc">
+          <input type="text" id="other">
+        </div>
+      `);
+      getWorkArea().append(div);
+      setFocusAndSelection("focused", "b");
+
+      let finalSrc = `
+        <div>
+          <input type="text" id="other">
+          <input type="text" id="focused" value="abc">
+        </div>
+      `;
+      Idiomorph.morph(div, finalSrc, {
+        morphStyle: "outerHTML",
+        restoreFocus: false,
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      if (document.moveBefore) {
+        assertFocusAndSelection("focused", "");
+      } else {
+        assertNoFocus();
+      }
+    });
+
+    it("retains focus but loses selection state when elements are moved to different levels of the DOM", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <input type="text" id="other">
+          <div>
+            <input type="text" id="focused" value="abc">
+          </div>
+        </div>
+      `;
+      setFocusAndSelection("focused", "b");
+
+      let finalSrc = `
+        <div>
+          <input type="text" id="other">
+          <input type="text" id="focused" value="abc">
+        </div>
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+        restoreFocus: false,
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      if (document.moveBefore) {
+        assertFocusAndSelection("focused", "");
+      } else {
+        assertNoFocus();
+      }
+    });
+
+    it("retains focus but loses selection state when elements are moved between different containers", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <div id="left">
+            <input type="text" id="focused" value="abc">
+          </div>
+          <div id="right">
+            <input type="text" id="other">
+          </div>
+        </div>
+      `;
+      setFocusAndSelection("focused", "b");
+
+      let finalSrc = `
+        <div>
+          <div id="left">
+            <input type="text" id="other">
+          </div>
+          <div id="right">
+            <input type="text" id="focused" value="abc">
+          </div>
+        </div>
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+        restoreFocus: false,
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      if (document.moveBefore) {
+        assertFocusAndSelection("focused", "");
+      } else {
+        assertNoFocus();
+      }
+    });
+
+    it("retains focus but loses selection state when parents are reordered", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <div id="left">
+            <input type="text" id="focused" value="abc">
+          </div>
+          <div id="right">
+            <input type="text" id="other">
+          </div>
+        </div>
+      `;
+      setFocusAndSelection("focused", "b");
+
+      let finalSrc = `
+        <div>
+          <div id="right">
+            <input type="text" id="other">
+          </div>
+          <div id="left">
+            <input type="text" id="focused" value="abc">
+          </div>
+        </div>
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+        restoreFocus: false,
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      if (document.moveBefore) {
+        assertFocusAndSelection("focused", "");
+      } else {
+        assertNoFocus();
+      }
+    });
+
+    it("retains focus but loses selection state with a textarea", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <textarea id="focused">abc</textarea>
+          <textarea id="other"></textarea>
+        </div>
+      `;
+      setFocusAndSelection("focused", "b");
+
+      let finalSrc = `
+        <div>
+          <textarea id="other"></textarea>
+          <textarea id="focused">abc</textarea>
+        </div>
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+        restoreFocus: false,
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      if (document.moveBefore) {
+        assertFocusAndSelection("focused", "");
+      } else {
+        assertNoFocus();
+      }
+    });
+
+    it("does nothing if a non input/textarea el is focused", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <p id="focused"></p>
+          <p id="other"></p>
+        </div>
+      `;
+      setFocus("focused");
+
+      let finalSrc = `
+        <div>
+          <p id="other"></p>
+          <p id="focused"></p>
+        </div>
+      `;
+      Idiomorph.morph(getWorkArea(), finalSrc, {
+        morphStyle: "innerHTML",
+        restoreFocus: false,
+      });
+
+      getWorkArea().innerHTML.should.equal(finalSrc);
+      assertNoFocus();
+    });
   });
 });

--- a/test/retain-hidden-state.js
+++ b/test/retain-hidden-state.js
@@ -194,6 +194,7 @@ describe("Hidden state preservation tests", function () {
         `;
     Idiomorph.morph(getWorkArea(), finalSrc, {
       morphStyle: "innerHTML",
+      restoreFocus: false, // to capture current reality of focus loss
     });
 
     getWorkArea().innerHTML.should.equal(finalSrc);
@@ -231,6 +232,7 @@ describe("Hidden state preservation tests", function () {
         `;
     Idiomorph.morph(getWorkArea(), finalSrc, {
       morphStyle: "innerHTML",
+      restoreFocus: false, // to capture current reality of focus loss
     });
 
     getWorkArea().innerHTML.should.equal(finalSrc);


### PR DESCRIPTION
## Summary
Default to using the new `restoreFocus` functionality. Any IDed element that loses focus and/or selection state due to being moved or reparented will have it manually restored after the morph. The downside to turning this on is an extra `focus` and/or `selection` event is fired in this case. If `moveBefore` is present, focus state is never lost, but selection state still is.

### Rationale:
The downside of a potential extra focus and/or selection event is less problematic than the downside of potentially losing the focus and/or selection itself.

If someone really finds the extra focus event to be problematic, they can simply opt into passing `restoreFocus: false`, and do something custom around calling `Idiomorph.morph`.

### Future plans
The next release after v0.5.0 should algorithmically preserve focus more often by morphing around the focused element.