### PR TITLE
Add a plugin system

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,23 +162,21 @@ The `head` object also offers callbacks for configuring head merging specifics.
 
 ### Plugins
 
-Idiomorph supports a plugin system that allows you to extend the functionality of the library, by registering an object of callbacks:
+Idiomorph supports a plugin system that allows you to extend the functionality of the library, by adding an object of callbacks:
 
 ```js
-Idiomorph.registerPlugin({
+Idiomorph.addPlugin({
     name: 'logger',
-    onBeforeNodeAdded: function(node) {
+    beforeNodeAdded: function(node) {
         console.log('Node added:', node);
     },
-    onBeforeNodeRemoved: function(node) {
+    beforeNodeRemoved: function(node) {
         console.log('Node removed:', node);
     },
 });
-
-Idiomorph.plugins // { logger: { ...} };
 ```
 
-These callbacks will be called in addition to any other callbacks that are registered in `Idiomorph.morph`. Multiple plugins can be registered.
+These callbacks will be called in addition to any other callbacks that are registered in `Idiomorph.morph`. Multiple plugins can be added.
 
 ### Setting Defaults
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,26 @@ Idiomorph.morph(document.documentElement, newPageSource, {head:{style: 'morph'}}
 
 The `head` object also offers callbacks for configuring head merging specifics.
 
+### Plugins
+
+Idiomorph supports a plugin system that allows you to extend the functionality of the library, by registering an object of callbacks:
+
+```js
+Idiomorph.registerPlugin({
+    name: 'logger',
+    onBeforeNodeAdded: function(node) {
+        console.log('Node added:', node);
+    },
+    onBeforeNodeRemoved: function(node) {
+        console.log('Node removed:', node);
+    },
+});
+
+Idiomorph.plugins // { logger: { ...} };
+```
+
+These callbacks will be called in addition to any other callbacks that are registered in `Idiomorph.morph`. Multiple plugins can be registered.
+
 ### Setting Defaults
 
 All the behaviors specified above can be set to a different default by mutating the `Idiomorph.defaults` object, including

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -171,6 +171,17 @@ var Idiomorph = (function () {
     return resultNode;
   }
 
+  function beforeAttributeUpdatedCallbacks(ctx, attr, element, updateType) {
+    const allPlugins = [...Object.values(plugins), ctx.callbacks];
+
+    const shouldAbort = allPlugins.some((plugin) => {
+      const beforeFn = plugin[`beforeAttributeUpdated`];
+      return beforeFn && beforeFn(attr, element, updateType) === false;
+    });
+
+    if (shouldAbort) return false;
+  }
+
   /**
    * Core idiomorph function for morphing one DOM tree to another
    *
@@ -839,7 +850,7 @@ var Idiomorph = (function () {
         return true;
       }
       return (
-        ctx.callbacks.beforeAttributeUpdated(attr, element, updateType) ===
+        beforeAttributeUpdatedCallbacks(ctx, attr, element, updateType) ===
         false
       );
     }

--- a/test/index.html
+++ b/test/index.html
@@ -45,6 +45,7 @@
     <script src="hooks.js"></script>
     <script src="htmx-integration.js"></script>
     <script src="ops.js"></script>
+    <script src="plugins.js"></script>
     <script src="preserve-focus.js"></script>
     <script src="restore-focus.js"></script>
     <script src="retain-hidden-state.js"></script>

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -29,6 +29,14 @@ function buildLoggingPlugin(name, log) {
         toString(newNode),
       ]);
     },
+    beforeAttributeUpdated: function (attribute, node, updateType) {
+      log.push([
+        `${name}:beforeAttributeUpdated`,
+        toString(node),
+        attribute,
+        updateType,
+      ]);
+    },
   };
 }
 
@@ -40,19 +48,49 @@ describe("Plugin system", function () {
     const plugin = buildLoggingPlugin("foo", log);
     Idiomorph.addPlugin(plugin);
 
-    Idiomorph.morph(make(`<p><br><a>A</a></p>`), `<hr><a>B</a>`, {
-      morphStyle: "innerHTML",
-    });
+    Idiomorph.morph(
+      make(`<p><br><a name="a" old="">A</a></p>`),
+      `<hr><a name="b" new="">B</a>`,
+      {
+        morphStyle: "innerHTML",
+      },
+    );
 
     log.should.eql([
       ["foo:beforeNodeAdded", "<hr>"],
       ["foo:afterNodeAdded", "<hr>"],
       ["foo:beforeNodeRemoved", "<br>"],
       ["foo:afterNodeRemoved", "<br>"],
-      ["foo:beforeNodeMorphed", "<a>A</a>", "<a>B</a>"],
+      [
+        "foo:beforeNodeMorphed",
+        `<a name="a" old="">A</a>`,
+        `<a name="b" new="">B</a>`,
+      ],
+      [
+        "foo:beforeAttributeUpdated",
+        `<a name="a" old="">A</a>`,
+        "name",
+        "update",
+      ],
+      [
+        "foo:beforeAttributeUpdated",
+        `<a name="b" old="">A</a>`,
+        "new",
+        "update",
+      ],
+      [
+        "foo:beforeAttributeUpdated",
+        `<a name="b" old="" new="">A</a>`,
+        "old",
+        "remove",
+      ],
       ["foo:beforeNodeMorphed", "A", "B"],
       ["foo:afterNodeMorphed", "B", "B"],
-      ["foo:afterNodeMorphed", "<a>B</a>", "<a>B</a>"],
+      [
+        "foo:afterNodeMorphed",
+        `<a name="b" new="">B</a>`,
+        `<a name="b" new="">B</a>`,
+      ],
     ]);
   });
 
@@ -63,9 +101,13 @@ describe("Plugin system", function () {
     Idiomorph.addPlugin(fooPlugin);
     Idiomorph.addPlugin(barPlugin);
 
-    Idiomorph.morph(make(`<p><br><a>A</a></p>`), `<hr><a>B</a>`, {
-      morphStyle: "innerHTML",
-    });
+    Idiomorph.morph(
+      make(`<p><br><a name="a" old="">A</a></p>`),
+      `<hr><a name="b" new="">B</a>`,
+      {
+        morphStyle: "innerHTML",
+      },
+    );
 
     log.should.eql([
       ["foo:beforeNodeAdded", "<hr>"],
@@ -76,14 +118,66 @@ describe("Plugin system", function () {
       ["bar:beforeNodeRemoved", "<br>"],
       ["bar:afterNodeRemoved", "<br>"],
       ["foo:afterNodeRemoved", "<br>"],
-      ["foo:beforeNodeMorphed", "<a>A</a>", "<a>B</a>"],
-      ["bar:beforeNodeMorphed", "<a>A</a>", "<a>B</a>"],
+      [
+        "foo:beforeNodeMorphed",
+        `<a name="a" old="">A</a>`,
+        `<a name="b" new="">B</a>`,
+      ],
+      [
+        "bar:beforeNodeMorphed",
+        `<a name="a" old="">A</a>`,
+        `<a name="b" new="">B</a>`,
+      ],
+      [
+        "foo:beforeAttributeUpdated",
+        `<a name="a" old="">A</a>`,
+        "name",
+        "update",
+      ],
+      [
+        "bar:beforeAttributeUpdated",
+        `<a name="a" old="">A</a>`,
+        "name",
+        "update",
+      ],
+      [
+        "foo:beforeAttributeUpdated",
+        `<a name="b" old="">A</a>`,
+        "new",
+        "update",
+      ],
+      [
+        "bar:beforeAttributeUpdated",
+        `<a name="b" old="">A</a>`,
+        "new",
+        "update",
+      ],
+      [
+        "foo:beforeAttributeUpdated",
+        `<a name="b" old="" new="">A</a>`,
+        "old",
+        "remove",
+      ],
+      [
+        "bar:beforeAttributeUpdated",
+        `<a name="b" old="" new="">A</a>`,
+        "old",
+        "remove",
+      ],
       ["foo:beforeNodeMorphed", "A", "B"],
       ["bar:beforeNodeMorphed", "A", "B"],
       ["bar:afterNodeMorphed", "B", "B"],
       ["foo:afterNodeMorphed", "B", "B"],
-      ["bar:afterNodeMorphed", "<a>B</a>", "<a>B</a>"],
-      ["foo:afterNodeMorphed", "<a>B</a>", "<a>B</a>"],
+      [
+        "bar:afterNodeMorphed",
+        `<a name="b" new="">B</a>`,
+        `<a name="b" new="">B</a>`,
+      ],
+      [
+        "foo:afterNodeMorphed",
+        `<a name="b" new="">B</a>`,
+        `<a name="b" new="">B</a>`,
+      ],
     ]);
   });
 
@@ -94,29 +188,49 @@ describe("Plugin system", function () {
     Idiomorph.addPlugin(fooPlugin);
     Idiomorph.addPlugin(barPlugin);
 
-    Idiomorph.morph(make(`<p><br><a>A</a></p>`), `<hr><a>B</a>`, {
-      morphStyle: "innerHTML",
-      callbacks: {
-        beforeNodeAdded: function (node) {
-          log.push([`beforeNodeAdded`, toString(node)]);
-        },
-        afterNodeAdded: function (node) {
-          log.push([`afterNodeAdded`, toString(node)]);
-        },
-        beforeNodeRemoved: function (node) {
-          log.push([`beforeNodeRemoved`, toString(node)]);
-        },
-        afterNodeRemoved: function (node) {
-          log.push([`afterNodeRemoved`, toString(node)]);
-        },
-        beforeNodeMorphed: function (oldNode, newNode) {
-          log.push([`beforeNodeMorphed`, toString(oldNode), toString(newNode)]);
-        },
-        afterNodeMorphed: function (oldNode, newNode) {
-          log.push([`afterNodeMorphed`, toString(oldNode), toString(newNode)]);
+    Idiomorph.morph(
+      make(`<p><br><a name="a" old="">A</a></p>`),
+      `<hr><a name="b" new="">B</a>`,
+      {
+        morphStyle: "innerHTML",
+        callbacks: {
+          beforeNodeAdded: function (node) {
+            log.push([`beforeNodeAdded`, toString(node)]);
+          },
+          afterNodeAdded: function (node) {
+            log.push([`afterNodeAdded`, toString(node)]);
+          },
+          beforeNodeRemoved: function (node) {
+            log.push([`beforeNodeRemoved`, toString(node)]);
+          },
+          afterNodeRemoved: function (node) {
+            log.push([`afterNodeRemoved`, toString(node)]);
+          },
+          beforeNodeMorphed: function (oldNode, newNode) {
+            log.push([
+              `beforeNodeMorphed`,
+              toString(oldNode),
+              toString(newNode),
+            ]);
+          },
+          afterNodeMorphed: function (oldNode, newNode) {
+            log.push([
+              `afterNodeMorphed`,
+              toString(oldNode),
+              toString(newNode),
+            ]);
+          },
+          beforeAttributeUpdated: function (attribute, node, updateType) {
+            log.push([
+              `beforeAttributeUpdated`,
+              toString(node),
+              attribute,
+              updateType,
+            ]);
+          },
         },
       },
-    });
+    );
 
     log.should.eql([
       ["foo:beforeNodeAdded", "<hr>"],
@@ -131,18 +245,86 @@ describe("Plugin system", function () {
       ["afterNodeRemoved", "<br>"],
       ["bar:afterNodeRemoved", "<br>"],
       ["foo:afterNodeRemoved", "<br>"],
-      ["foo:beforeNodeMorphed", "<a>A</a>", "<a>B</a>"],
-      ["bar:beforeNodeMorphed", "<a>A</a>", "<a>B</a>"],
-      ["beforeNodeMorphed", "<a>A</a>", "<a>B</a>"],
+      [
+        "foo:beforeNodeMorphed",
+        `<a name="a" old="">A</a>`,
+        `<a name="b" new="">B</a>`,
+      ],
+      [
+        "bar:beforeNodeMorphed",
+        `<a name="a" old="">A</a>`,
+        `<a name="b" new="">B</a>`,
+      ],
+      [
+        "beforeNodeMorphed",
+        `<a name="a" old="">A</a>`,
+        `<a name="b" new="">B</a>`,
+      ],
+      [
+        "foo:beforeAttributeUpdated",
+        `<a name="a" old="">A</a>`,
+        "name",
+        "update",
+      ],
+      [
+        "bar:beforeAttributeUpdated",
+        `<a name="a" old="">A</a>`,
+        "name",
+        "update",
+      ],
+      ["beforeAttributeUpdated", `<a name="a" old="">A</a>`, "name", "update"],
+      [
+        "foo:beforeAttributeUpdated",
+        `<a name="b" old="">A</a>`,
+        "new",
+        "update",
+      ],
+      [
+        "bar:beforeAttributeUpdated",
+        `<a name="b" old="">A</a>`,
+        "new",
+        "update",
+      ],
+      ["beforeAttributeUpdated", `<a name="b" old="">A</a>`, "new", "update"],
+      [
+        "foo:beforeAttributeUpdated",
+        `<a name="b" old="" new="">A</a>`,
+        "old",
+        "remove",
+      ],
+      [
+        "bar:beforeAttributeUpdated",
+        `<a name="b" old="" new="">A</a>`,
+        "old",
+        "remove",
+      ],
+      [
+        "beforeAttributeUpdated",
+        `<a name="b" old="" new="">A</a>`,
+        "old",
+        "remove",
+      ],
       ["foo:beforeNodeMorphed", "A", "B"],
       ["bar:beforeNodeMorphed", "A", "B"],
       ["beforeNodeMorphed", "A", "B"],
       ["afterNodeMorphed", "B", "B"],
       ["bar:afterNodeMorphed", "B", "B"],
       ["foo:afterNodeMorphed", "B", "B"],
-      ["afterNodeMorphed", "<a>B</a>", "<a>B</a>"],
-      ["bar:afterNodeMorphed", "<a>B</a>", "<a>B</a>"],
-      ["foo:afterNodeMorphed", "<a>B</a>", "<a>B</a>"],
+      [
+        "afterNodeMorphed",
+        `<a name="b" new="">B</a>`,
+        `<a name="b" new="">B</a>`,
+      ],
+      [
+        "bar:afterNodeMorphed",
+        `<a name="b" new="">B</a>`,
+        `<a name="b" new="">B</a>`,
+      ],
+      [
+        "foo:afterNodeMorphed",
+        `<a name="b" new="">B</a>`,
+        `<a name="b" new="">B</a>`,
+      ],
     ]);
   });
 
@@ -184,6 +366,44 @@ describe("Plugin system", function () {
     log.should.eql([["foo:beforeNodeAdded", "<hr>"]]);
   });
 
+  it("the first beforeNodeMorphed => false halts the entire operation", function () {
+    let log = [];
+
+    Idiomorph.addPlugin({
+      name: "foo",
+      beforeNodeMorphed: function (node) {
+        log.push(["foo:beforeNodeMorphed", node.outerHTML]);
+        return false;
+      },
+      afterNodeMorphed: function (node) {
+        log.push(["foo:afterNodeMorphed", node.outerHTML]);
+      },
+    });
+
+    Idiomorph.addPlugin({
+      name: "bar",
+      beforeNodeMorphed: function (node) {
+        log.push(["bar:beforeNodeMorphed", node.outerHTML]);
+      },
+      afterNodeMorphed: function (node) {
+        log.push(["bar:afterNodeMorphed", node.outerHTML]);
+      },
+    });
+
+    Idiomorph.morph(make(`<hr name="a">`), `<hr name="b">`, {
+      callbacks: {
+        beforeNodeMorphed: function (node) {
+          log.push(["beforeNodeMorphed", node.outerHTML]);
+        },
+        afterNodeMorphed: function (node) {
+          log.push(["afterNodeMorphed", node.outerHTML]);
+        },
+      },
+    });
+
+    log.should.eql([["foo:beforeNodeMorphed", `<hr name="a">`]]);
+  });
+
   it("the first beforeNodeRemoved => false halts the entire operation", function () {
     let log = [];
 
@@ -201,10 +421,10 @@ describe("Plugin system", function () {
     Idiomorph.addPlugin({
       name: "bar",
       beforeNodeRemoved: function (node) {
-        log.push(["bar:beforeNodeRemoved2", node.outerHTML]);
+        log.push(["bar:beforeNodeRemoved", node.outerHTML]);
       },
       afterNodeRemoved: function (node) {
-        log.push(["bar:afterNodeRemoved2", node.outerHTML]);
+        log.push(["bar:afterNodeRemoved", node.outerHTML]);
       },
     });
 
@@ -220,6 +440,35 @@ describe("Plugin system", function () {
     });
 
     log.should.eql([["foo:beforeNodeRemoved", "<br>"]]);
+  });
+
+  it("the first beforeAttributeUpdated => false halts the entire operation", function () {
+    let log = [];
+
+    Idiomorph.addPlugin({
+      name: "foo",
+      beforeAttributeUpdated: function (attr, node, updateType) {
+        log.push(["foo:beforeAttributeUpdated", node.outerHTML]);
+        return false;
+      },
+    });
+
+    Idiomorph.addPlugin({
+      name: "bar",
+      beforeAttributeUpdated: function (attr, node, updateType) {
+        log.push(["bar:beforeAttributeUpdated", node.outerHTML]);
+      },
+    });
+
+    Idiomorph.morph(make(`<hr name="a">`), `<hr name="b">`, {
+      callbacks: {
+        beforeAttributeUpdated: function (attr, node, updateType) {
+          log.push(["beforeAttributeUpdated", node.outerHTML]);
+        },
+      },
+    });
+
+    log.should.eql([["foo:beforeAttributeUpdated", `<hr name="a">`]]);
   });
 
   it("plugin callbacks are not all required to exist", function () {

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -1,0 +1,277 @@
+describe("Plugin system", function () {
+  setup();
+
+  it("can add plugins", function () {
+    let calls = [];
+
+    const plugin = {
+      name: "foo",
+      beforeNodeAdded: function (node) {
+        calls.push(["beforeNodeAdded", node.outerHTML]);
+      },
+      afterNodeAdded: function (node) {
+        calls.push(["afterNodeAdded", node.outerHTML]);
+      },
+      beforeNodeRemoved: function (node) {
+        calls.push(["beforeNodeRemoved", node.outerHTML]);
+      },
+      afterNodeRemoved: function (node) {
+        calls.push(["afterNodeRemoved", node.outerHTML]);
+      },
+    };
+    Idiomorph.addPlugin(plugin);
+
+    Idiomorph.morph(make("<br>"), "<hr>");
+
+    calls.should.eql([
+      ["beforeNodeAdded", "<hr>"],
+      ["afterNodeAdded", "<hr>"],
+      ["beforeNodeRemoved", "<br>"],
+      ["afterNodeRemoved", "<br>"],
+    ]);
+  });
+
+  it("can add multiple plugins", function () {
+    let calls = [];
+
+    const plugin1 = {
+      name: "foo",
+      beforeNodeAdded: function (node) {
+        calls.push(["beforeNodeAdded1", node.outerHTML]);
+      },
+      afterNodeAdded: function (node) {
+        calls.push(["afterNodeAdded1", node.outerHTML]);
+      },
+      beforeNodeRemoved: function (node) {
+        calls.push(["beforeNodeRemoved1", node.outerHTML]);
+      },
+      afterNodeRemoved: function (node) {
+        calls.push(["afterNodeRemoved1", node.outerHTML]);
+      },
+    };
+    Idiomorph.addPlugin(plugin1);
+
+    const plugin2 = {
+      name: "bar",
+      beforeNodeAdded: function (node) {
+        calls.push(["beforeNodeAdded2", node.outerHTML]);
+      },
+      afterNodeAdded: function (node) {
+        calls.push(["afterNodeAdded2", node.outerHTML]);
+      },
+      beforeNodeRemoved: function (node) {
+        calls.push(["beforeNodeRemoved2", node.outerHTML]);
+      },
+      afterNodeRemoved: function (node) {
+        calls.push(["afterNodeRemoved2", node.outerHTML]);
+      },
+    };
+    Idiomorph.addPlugin(plugin2);
+
+    Idiomorph.morph(make("<br>"), "<hr>");
+
+    calls.should.eql([
+      ["beforeNodeAdded1", "<hr>"],
+      ["beforeNodeAdded2", "<hr>"],
+      ["afterNodeAdded2", "<hr>"],
+      ["afterNodeAdded1", "<hr>"],
+      ["beforeNodeRemoved1", "<br>"],
+      ["beforeNodeRemoved2", "<br>"],
+      ["afterNodeRemoved2", "<br>"],
+      ["afterNodeRemoved1", "<br>"],
+    ]);
+  });
+
+  it("can add multiple plugins alongside callbacks", function () {
+    let calls = [];
+
+    const plugin1 = {
+      name: "foo",
+      beforeNodeAdded: function (node) {
+        calls.push(["beforeNodeAdded1", node.outerHTML]);
+      },
+      afterNodeAdded: function (node) {
+        calls.push(["afterNodeAdded1", node.outerHTML]);
+      },
+      beforeNodeRemoved: function (node) {
+        calls.push(["beforeNodeRemoved1", node.outerHTML]);
+      },
+      afterNodeRemoved: function (node) {
+        calls.push(["afterNodeRemoved1", node.outerHTML]);
+      },
+    };
+    Idiomorph.addPlugin(plugin1);
+
+    const plugin2 = {
+      name: "bar",
+      beforeNodeAdded: function (node) {
+        calls.push(["beforeNodeAdded2", node.outerHTML]);
+      },
+      afterNodeAdded: function (node) {
+        calls.push(["afterNodeAdded2", node.outerHTML]);
+      },
+      beforeNodeRemoved: function (node) {
+        calls.push(["beforeNodeRemoved2", node.outerHTML]);
+      },
+      afterNodeRemoved: function (node) {
+        calls.push(["afterNodeRemoved2", node.outerHTML]);
+      },
+    };
+    Idiomorph.addPlugin(plugin2);
+
+    Idiomorph.morph(make("<br>"), "<hr>", {
+      callbacks: {
+        beforeNodeAdded: function (node) {
+          calls.push(["beforeNodeAddedCallback", node.outerHTML]);
+        },
+        afterNodeAdded: function (node) {
+          calls.push(["afterNodeAddedCallback", node.outerHTML]);
+        },
+        beforeNodeRemoved: function (node) {
+          calls.push(["beforeNodeRemovedCallback", node.outerHTML]);
+        },
+        afterNodeRemoved: function (node) {
+          calls.push(["afterNodeRemovedCallback", node.outerHTML]);
+        },
+      },
+    });
+
+    calls.should.eql([
+      ["beforeNodeAdded1", "<hr>"],
+      ["beforeNodeAdded2", "<hr>"],
+      ["beforeNodeAddedCallback", "<hr>"],
+      ["afterNodeAddedCallback", "<hr>"],
+      ["afterNodeAdded2", "<hr>"],
+      ["afterNodeAdded1", "<hr>"],
+      ["beforeNodeRemoved1", "<br>"],
+      ["beforeNodeRemoved2", "<br>"],
+      ["beforeNodeRemovedCallback", "<br>"],
+      ["afterNodeRemovedCallback", "<br>"],
+      ["afterNodeRemoved2", "<br>"],
+      ["afterNodeRemoved1", "<br>"],
+    ]);
+  });
+
+  it("the first beforeNodeAdded => false halts the entire operation", function () {
+    let calls = [];
+
+    const plugin1 = {
+      name: "foo",
+      beforeNodeAdded: function (node) {
+        calls.push(["beforeNodeAdded1", node.outerHTML]);
+        return false;
+      },
+      afterNodeAdded: function (node) {
+        calls.push(["afterNodeAdded1", node.outerHTML]);
+      },
+    };
+    Idiomorph.addPlugin(plugin1);
+
+    const plugin2 = {
+      name: "bar",
+      beforeNodeAdded: function (node) {
+        calls.push(["beforeNodeAdded2", node.outerHTML]);
+      },
+      afterNodeAdded: function (node) {
+        calls.push(["afterNodeAdded2", node.outerHTML]);
+      },
+    };
+    Idiomorph.addPlugin(plugin2);
+
+    Idiomorph.morph(make("<p>"), "<p><hr>", {
+      callbacks: {
+        beforeNodeAdded: function (node) {
+          calls.push(["beforeNodeAddedCallback", node.outerHTML]);
+        },
+        afterNodeAdded: function (node) {
+          calls.push(["afterNodeAddedCallback", node.outerHTML]);
+        },
+      },
+    });
+
+    calls.should.eql([
+      ["beforeNodeAdded1", "<hr>"]
+    ]);
+  });
+
+  it("the first beforeNodeRemoved => false halts the entire operation", function () {
+    let calls = [];
+
+    const plugin1 = {
+      name: "foo",
+      beforeNodeRemoved: function (node) {
+        calls.push(["beforeNodeRemoved1", node.outerHTML]);
+        return false
+      },
+      afterNodeRemoved: function (node) {
+        calls.push(["afterNodeRemoved1", node.outerHTML]);
+      },
+    };
+    Idiomorph.addPlugin(plugin1);
+
+    const plugin2 = {
+      name: "bar",
+      beforeNodeRemoved: function (node) {
+        calls.push(["beforeNodeRemoved2", node.outerHTML]);
+      },
+      afterNodeRemoved: function (node) {
+        calls.push(["afterNodeRemoved2", node.outerHTML]);
+      },
+    };
+    Idiomorph.addPlugin(plugin2);
+
+    Idiomorph.morph(make("<br>"), "<hr>", {
+      callbacks: {
+        beforeNodeRemoved: function (node) {
+          calls.push(["beforeNodeRemovedCallback", node.outerHTML]);
+        },
+        afterNodeRemoved: function (node) {
+          calls.push(["afterNodeRemovedCallback", node.outerHTML]);
+        },
+      },
+    });
+
+    calls.should.eql([
+      ["beforeNodeRemoved1", "<br>"]
+    ]);
+  });
+
+  it("plugin callbacks are not all required to exist", function () {
+    let calls = [];
+
+    const plugin1 = {
+      name: "foo",
+      beforeNodeAdded: function (node) {
+        calls.push(["beforeNodeAdded1", node.outerHTML]);
+      },
+      afterNodeAdded: function (node) {
+        calls.push(["afterNodeAdded1", node.outerHTML]);
+      },
+    };
+    Idiomorph.addPlugin(plugin1);
+
+    const plugin2 = {
+      name: "bar",
+    };
+    Idiomorph.addPlugin(plugin2);
+
+    Idiomorph.morph(make("<br>"), "<hr>", {
+      callbacks: {
+        beforeNodeAdded: function (node) {
+          calls.push(["beforeNodeAddedCallback", node.outerHTML]);
+        },
+        afterNodeAdded: function (node) {
+          calls.push(["afterNodeAddedCallback", node.outerHTML]);
+        },
+      },
+    });
+
+    calls.should.eql([
+      ["beforeNodeAdded1", "<hr>"],
+      ["beforeNodeAddedCallback", "<hr>"],
+      ["afterNodeAddedCallback", "<hr>"],
+      ["afterNodeAdded1", "<hr>"],
+    ]);
+  });
+});
+


### PR DESCRIPTION
## Overview
I think Idiomorph could benefit from a plugin system.

The idea here to is make it easy to encapsulate useful ideas and integrations in individual files or packages, e.g. "idiomorph/ignore-value", "idiomorph/htmx", "idiomorph/ignore-active-value", "idiomorph/turbo", etc. Multiple plugins should be able to be easily composed.

## Example
```js
Idiomorph.addPlugin({
    name: 'logger',
    beforeNodeAdded: function(node) {
        console.log('Node added:', node);
    },
    beforeNodeRemoved: function(node) {
        console.log('Node removed:', node);
    },
});
```

## Benefits
* Potentially slimming down core by extracting less-frequently-used options into plugins. For example, `ignoreActive` or `ignoreActiveValue` might be good candidates for this.
* Allowing transparent composition of different callback-related concerns. Right now, all lifecycle callbacks are singletons. So if one wants to register multiple `beforeNodeMorphed` callbacks, for example, they'd have to manually compose the individual functions themselves.
* Enabling experimentation and third-party integration outside of core. This could enable third-party npm packages to be published that provide an Idiomorph integration or modification, without requiring us to merge anything into core.
* May be internally useful for core, for separating concerns.

## Questions
* How do we want the interface to be? Should we name it `defineExtension` to line up with its cousin, htmx?
* Can this system support `require`, `import`, and `<script src>`?
* What if we don't control the Idiomorph call itself? For example, Idiomorph is a hidden implementation detail of Turbo. Could a user of Turbo add a plugin to Idiomorph, even though it's buried within the guts of Turbo?

So, is this a good idea? What do we think about the API?