### PR TITLE
Changes to testing system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  test:
+  test-chromium:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -14,10 +14,42 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm install
-      - name: Install browsers
-        run: npx playwright install --with-deps
+      - name: Install browser
+        run: npx playwright install --with-deps chromium
       - name: Run tests
-        run: npm run ci
+        run: npm run test:chrome --fail-only
+
+  test-firefox:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Install browser
+        run: npx playwright install --with-deps firefox
+      - name: Run tests
+        run: npm run test:firefox --fail-only
+
+  test-webkit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Install browser
+        run: npx playwright install --with-deps webkit
+      - name: Run tests
+        run: npm run test:webkit --fail-only
 
   coverage:
     runs-on: ubuntu-latest
@@ -31,7 +63,7 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Install browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium
       - name: Run tests
         run: npm run test:coverage
       - name: Upload coverage report

--- a/TESTING.md
+++ b/TESTING.md
@@ -21,9 +21,16 @@ This will run all the tests using headless Chrome.
 
 To run all tests against all browsers in headless mode, execute:
 ```bash
-npm run ci
+npm run test:all
 ```
-This will run the tests using Playwright’s headless browser setup across Chrome, Firefox, and WebKit (Safari-adjacent). This is ultimately what gets run in Github Actions to verify PRs. This build will fail if there is an `it.only` left in the codebase, thanks to a custom `--fail-only` command line argument.
+This will run the tests using Playwright’s headless browser setup across Chrome, Firefox, and WebKit (Safari-adjacent).
+
+To run all tests against a specific browser, execute:
+```bash
+npm run test:chrome
+npm run test:firefox
+npm run test:webkit
+```
 
 ## Running Individual Tests
 
@@ -48,14 +55,6 @@ npm run test:debug
 ```
 This will start the server, and open the test runner in a browser. From there you can choose a test file to run.
 
-## GitHub Actions CI matrix
-On each push and PR, GitHub Actions runs the following test matrix:
-
-1. `npm run ci` - Run all tests on Chrome, Firefox, and WebKit.
-2. `npm run test:coverage` - Run all tests, and fail if coverage is below 100%.
-3. `npm run typecheck` - Run TypeScript type checking.
-4. `npm run format:check`- Check that all files are formatted correctly.
-
 ## Code Coverage Report
 After a test run completes, you can open `coverage/lcov-report/index.html` to view the code coverage report. On Ubuntu you can run:
 ```bash
@@ -65,6 +64,21 @@ xdg-open coverage/lcov-report/index.html
 ## Test Locations
 - All tests are located in the `test/` directory. Only .js files in this directory will be discovered by the test runner, so support files can go in subdirectories.
 - The `web-test-runner.config.mjs` file in the root directory contains the boilerplate HTML for the test runs, including `<script>` tags for the test dependencies.
+
+## GitHub Actions CI matrix
+On each push and PR, GitHub Actions runs the following test matrix:
+
+1. `npm run test:chrome --fail-only` - Run all tests on Chrome, failing if there is an `it.only` left in the codebase.
+2. `npm run test:firefox --fail-only` - Run all tests on Firefox, failing if there is an `it.only` left in the codebase.
+3. `npm run test:webkit --fail-only` - Run all tests on WebKit, failing if there is an `it.only` left in the codebase.
+4. `npm run test:coverage` - Run all tests on Chrome, and fail if coverage is below 100%.
+5. `npm run typecheck` - Run TypeScript type checking.
+6. `npm run format:check`- Check that all files are formatted correctly.
+
+The custom `--fail-only` command line argument is implemented in `test/lib/fail-only.mjs`.
+
+### Local CI prediction
+You can run `npm run test:ci` to locally simulate the result of the CI run. This is useful to run before pushing to GitHub to avoid fixup commits and CI reruns.
 
 ## Performance Benchmarks
 See [PERFORMANCE.md](PERFORMANCE.md) for information on running performance benchmarks.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:chrome": "web-test-runner --playwright --browsers chromium",
     "test:firefox": "web-test-runner --concurrency 1 --playwright --browsers firefox",
     "test:webkit": "web-test-runner --playwright --browsers webkit",
+    "test:all": "web-test-runner --concurrency 1 --playwright --browsers chromium firefox webkit",
     "test:coverage": "npm run test:chrome && node test/lib/ensure-full-coverage.js",
     "perf": "node perf/runner.js",
     "amd": "(echo \"define(() => {\n\" && cat src/idiomorph.js && echo \"\nreturn Idiomorph});\") > dist/idiomorph.amd.js",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
   },
   "scripts": {
     "test": "web-test-runner",
-    "test:coverage": "npm run ci && node test/lib/ensure-full-coverage.js",
     "test:debug": "web-test-runner --manual --open",
-    "ci": "web-test-runner --fail-only --playwright --browsers chromium firefox webkit",
+    "test:chrome": "web-test-runner --playwright --browsers chromium",
+    "test:firefox": "web-test-runner --playwright --browsers firefox",
+    "test:webkit": "web-test-runner --playwright --browsers webkit",
+    "test:coverage": "npm run test:chrome && node test/lib/ensure-full-coverage.js",
     "perf": "node perf/runner.js",
     "amd": "(echo \"define(() => {\n\" && cat src/idiomorph.js && echo \"\nreturn Idiomorph});\") > dist/idiomorph.amd.js",
     "cjs": "(cat src/idiomorph.js && echo \"\nmodule.exports = Idiomorph;\") > dist/idiomorph.cjs.js",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:firefox": "web-test-runner --concurrency 1 --playwright --browsers firefox",
     "test:webkit": "web-test-runner --playwright --browsers webkit",
     "test:all": "web-test-runner --concurrency 1 --playwright --browsers chromium firefox webkit",
+    "test:ci": "npm run typecheck && npm run format:check && npm run test:all -- --fail-only && node test/lib/ensure-full-coverage.js",
     "test:coverage": "npm run test:chrome && node test/lib/ensure-full-coverage.js",
     "perf": "node perf/runner.js",
     "amd": "(echo \"define(() => {\n\" && cat src/idiomorph.js && echo \"\nreturn Idiomorph});\") > dist/idiomorph.amd.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "web-test-runner",
     "test:debug": "web-test-runner --manual --open",
     "test:chrome": "web-test-runner --playwright --browsers chromium",
-    "test:firefox": "web-test-runner --playwright --browsers firefox",
+    "test:firefox": "web-test-runner --concurrency 1 --playwright --browsers firefox",
     "test:webkit": "web-test-runner --playwright --browsers webkit",
     "test:coverage": "npm run test:chrome && node test/lib/ensure-full-coverage.js",
     "perf": "node perf/runner.js",

--- a/test/lib/utilities.js
+++ b/test/lib/utilities.js
@@ -2,9 +2,6 @@
 
 function setup() {
     beforeEach(() => {
-        if (window.useMoveBefore && !Element.prototype.moveBefore) {
-            throw new Error('Element.prototype.moveBefore is not available.');
-        }
         clearWorkArea();
     });
 }


### PR DESCRIPTION
Four changes here to the testing system:

1. Remove `npm run ci`, and replace with `npm run test:chrome`, `npm run test:firefox`, and `npm run test:webkit`. GitHub CI runs each one of these in its own job now. This is primarily to enable...
2. Force Firefox test runs to run with concurrency disabled. Closes #113.
3. Add `npm run test:all` for running in all three browsers locally, now that we no longer have `npm run ci`.
4. Add `npm run test:ci` to simulate the result of a GitHub Actions CI run. This is useful for running before pushing, to avoid fixup commits and CI reruns.

TESTING.md has been updated accordingly.

@MichaelWest22 FYI