### PR TITLE
retain focus by breaking on active during findBestMatch

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -432,6 +432,10 @@ var Idiomorph = (function () {
             }
           }
 
+          // if the current node contains active element, stop looking for better future matches,
+          // because if one is found, this node will be moved to the pantry, reparenting it and thus losing focus
+          if (cursor.contains(document.activeElement)) break;
+
           cursor = cursor.nextSibling;
         }
 

--- a/test/preserve-focus.js
+++ b/test/preserve-focus.js
@@ -22,7 +22,7 @@ describe("Preserves focus algorithmically where possible", function () {
     }
   }
 
-  it("preserves focus state and outerHTML morphStyle", function () {
+  it("preserves focus state when elements are swapped", function () {
     assertFocusPreservation(
       `
       <div>
@@ -36,16 +36,24 @@ describe("Preserves focus algorithmically where possible", function () {
       </div>`,
       "focused",
       "b",
-      false, // skip assertion
     );
-    if (hasMoveBefore()) {
-      assertFocus("focused");
-      // TODO moveBefore loses selection on Chrome 131.0.6778.264
-      // expect will be fixed in future release
-      // assertFocusAndSelection("focused", "b");
-    } else {
-      assertNoFocus();
-    }
+  });
+
+  it("preserves focus state when elements are swapped the other way", function () {
+    assertFocusPreservation(
+      `
+      <div>
+        <input type="text" id="other">
+        <input type="text" id="focused" value="abc">
+      </div>`,
+      `
+      <div>
+        <input type="text" id="focused" value="abc">
+        <input type="text" id="other">
+      </div>`,
+      "focused",
+      "b",
+    );
   });
 
   it("preserves focus state when previous element is replaced", function () {
@@ -85,7 +93,7 @@ describe("Preserves focus algorithmically where possible", function () {
     );
     if (hasMoveBefore()) {
       assertFocus("focused");
-      // TODO moveBefore loses selection on Chrome 131.0.6778.264
+      // TODO moveBefore loses selection on Chrome 133
       // expect will be fixed in future release
       // assertFocusAndSelection("focused", "b");
     } else {
@@ -113,7 +121,7 @@ describe("Preserves focus algorithmically where possible", function () {
     );
     if (hasMoveBefore()) {
       assertFocus("focused");
-      // TODO moveBefore loses selection on Chrome 131.0.6778.264
+      // TODO moveBefore loses selection on Chrome 133
       // expect will be fixed in future release
       // assertFocusAndSelection("focused", "b");
     } else {
@@ -147,7 +155,7 @@ describe("Preserves focus algorithmically where possible", function () {
     );
     if (hasMoveBefore()) {
       assertFocus("focused");
-      // TODO moveBefore loses selection on Chrome 131.0.6778.264
+      // TODO moveBefore loses selection on Chrome 133
       // expect will be fixed in future release
       // assertFocusAndSelection("focused", "b");
     } else {
@@ -177,16 +185,7 @@ describe("Preserves focus algorithmically where possible", function () {
       </div>`,
       "focused",
       "b",
-      false, // skip assertion
     );
-    if (hasMoveBefore()) {
-      assertFocus("focused");
-      // TODO moveBefore loses selection on Chrome 131.0.6778.264
-      // expect will be fixed in future release
-      // assertFocusAndSelection("focused", "b");
-    } else {
-      assertNoFocus();
-    }
   });
 
   it("preserves focus state when focus parent is moved up", function () {
@@ -231,15 +230,6 @@ describe("Preserves focus algorithmically where possible", function () {
       </div>`,
       "focused",
       "b",
-      false,
     );
-    if (hasMoveBefore()) {
-      assertFocus("focused");
-      // TODO moveBefore loses selection on Chrome 131.0.6778.264
-      // expect will be fixed in future release
-      // assertFocusAndSelection("focused", "b");
-    } else {
-      assertNoFocus();
-    }
   });
 });

--- a/test/restore-focus.js
+++ b/test/restore-focus.js
@@ -291,7 +291,7 @@ describe("Option to forcibly restore focus after morph", function () {
   });
 
   describe("with option off", function () {
-    it("retains focus but loses selection state with outerHTML morphStyle", function () {
+    it("retains focus and selection state with outerHTML morphStyle", function () {
       const div = make(`
         <div>
           <input type="text" id="focused" value="abc">
@@ -313,11 +313,7 @@ describe("Option to forcibly restore focus after morph", function () {
       });
 
       getWorkArea().innerHTML.should.equal(finalSrc);
-      if (document.moveBefore) {
-        assertFocusAndSelection("focused", "");
-      } else {
-        assertNoFocus();
-      }
+      assertFocusAndSelection("focused", "b");
     });
 
     it("retains focus but loses selection state when elements are moved to different levels of the DOM", function () {
@@ -386,7 +382,7 @@ describe("Option to forcibly restore focus after morph", function () {
       }
     });
 
-    it("retains focus but loses selection state when parents are reorderd", function () {
+    it("retains focus and selection state when parents are reorderd", function () {
       getWorkArea().innerHTML = `
         <div>
           <div id="left">
@@ -415,14 +411,10 @@ describe("Option to forcibly restore focus after morph", function () {
       });
 
       getWorkArea().innerHTML.should.equal(finalSrc);
-      if (document.moveBefore) {
-        assertFocusAndSelection("focused", "");
-      } else {
-        assertNoFocus();
-      }
+      assertFocusAndSelection("focused", "b");
     });
 
-    it("retains focus but loses selection state with outerHTML morphStyle", function () {
+    it("retains focus and selection state with outerHTML morphStyle", function () {
       const div = make(`
         <div>
           <input type="text" id="focused" value="abc">
@@ -444,11 +436,7 @@ describe("Option to forcibly restore focus after morph", function () {
       });
 
       getWorkArea().innerHTML.should.equal(finalSrc);
-      if (document.moveBefore) {
-        assertFocusAndSelection("focused", "");
-      } else {
-        assertNoFocus();
-      }
+      assertFocusAndSelection("focused", "b");
     });
 
     it("retains focus but loses selection state when elements are moved to different levels of the DOM", function () {
@@ -517,7 +505,7 @@ describe("Option to forcibly restore focus after morph", function () {
       }
     });
 
-    it("retains focus but loses selection state when parents are reordered", function () {
+    it("retains focus and selection state when parents are reordered", function () {
       getWorkArea().innerHTML = `
         <div>
           <div id="left">
@@ -546,14 +534,10 @@ describe("Option to forcibly restore focus after morph", function () {
       });
 
       getWorkArea().innerHTML.should.equal(finalSrc);
-      if (document.moveBefore) {
-        assertFocusAndSelection("focused", "");
-      } else {
-        assertNoFocus();
-      }
+      assertFocusAndSelection("focused", "b");
     });
 
-    it("retains focus but loses selection state with a textarea", function () {
+    it("retains focus and selection state with a textarea", function () {
       getWorkArea().innerHTML = `
         <div>
           <textarea id="focused">abc</textarea>
@@ -574,11 +558,7 @@ describe("Option to forcibly restore focus after morph", function () {
       });
 
       getWorkArea().innerHTML.should.equal(finalSrc);
-      if (document.moveBefore) {
-        assertFocusAndSelection("focused", "");
-      } else {
-        assertNoFocus();
-      }
+      assertFocusAndSelection("focused", "b");
     });
 
     it("does nothing if a non input/textarea el is focused", function () {
@@ -693,7 +673,7 @@ describe("Option to forcibly restore focus after morph", function () {
   });
 
   describe("with option off but moveBefore disabled", function () {
-    it("does not preserves focus state and outerHTML morphStyle", function () {
+    it("preserves focus state and outerHTML morphStyle", function () {
       assertFocusPreservationWithoutMoveBefore(
         `
         <div>
@@ -709,7 +689,7 @@ describe("Option to forcibly restore focus after morph", function () {
         "b",
         false,
       );
-      assertNoFocus("focused");
+      assertFocus("focused");
     });
 
     it("does not preserves focus state when elements are moved to different levels of the DOM", function () {


### PR DESCRIPTION
I found that by getting the findBestMatch to break out of its searching loop when it finds the active element it will then either match on the current softmatch or return null which then causes any required elements to be inserted before the active element instead of displacing the active focused element.  With this we are able to retain full focus and selection in almost all cases possible.  Focus is still lost without moveBefore or restoreFocus in situations where we can't retain focus like moving an input to different levels in the DOM. Also it does still lose focus in the tests where the focused input is moved down to another div but a preservable id element is left in the old div which still matches first causing possible focus loss.

I Updated and renamed all the many now fixed tests.  Note this does leave us with some redundancy in our tests we could probably clean up later.