### PR TITLE
only restore selection when needed in restoreFocuse

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -216,8 +216,10 @@ var Idiomorph = (function () {
    */
   function saveAndRestoreFocus(ctx, fn) {
     if (!ctx.config.restoreFocus) return fn();
-
-    let activeElement = document.activeElement;
+    let activeElement =
+      /** @type {HTMLInputElement|HTMLTextAreaElement|null} */ (
+        document.activeElement
+      );
 
     // don't bother if the active element is not an input or textarea
     if (
@@ -235,11 +237,9 @@ var Idiomorph = (function () {
 
     if (activeElementId && activeElementId !== document.activeElement?.id) {
       activeElement = ctx.target.querySelector(`#${activeElementId}`);
-      // @ts-ignore we can assume this is focusable
       activeElement?.focus();
     }
-    if (activeElement && selectionStart && selectionEnd) {
-      // @ts-ignore we know this is an input element
+    if (activeElement && !activeElement.selectionEnd && selectionEnd) {
       activeElement.setSelectionRange(selectionStart, selectionEnd);
     }
 

--- a/test/restore-focus.js
+++ b/test/restore-focus.js
@@ -54,7 +54,7 @@ describe("Option to forcibly restore focus after morph", function () {
           </div>
         </div>
       `;
-      setFocusAndSelection("focused", "b");
+      setFocusAndSelection("focused", "a");
 
       let finalSrc = `
         <div>
@@ -67,7 +67,7 @@ describe("Option to forcibly restore focus after morph", function () {
       });
 
       getWorkArea().innerHTML.should.equal(finalSrc);
-      assertFocusAndSelection("focused", "b");
+      assertFocusAndSelection("focused", "a");
     });
 
     it("restores focus and selection state when elements are moved between different containers", function () {
@@ -287,6 +287,32 @@ describe("Option to forcibly restore focus after morph", function () {
 
       getWorkArea().innerHTML.should.equal(finalSrc);
       assertNoFocus();
+    });
+
+    it("does not restore selection if selection still set or changed", function () {
+      getWorkArea().innerHTML = `
+          <div>
+            <input type="text" id="focused" value="abc">
+            <input type="text" id="other">
+          </div>`
+      const after = `
+          <div>
+            <input type="text" id="other">
+            <input type="text" id="focused" value="abc">
+          </div>`
+      setFocusAndSelection("focused", "b");
+      Idiomorph.morph(getWorkArea(), after, {
+        morphStyle: "innerHTML",
+        restoreFocus: true,
+        callbacks: {
+          beforeNodeMorphed: function () {
+            // simulate changing the focus selection during morphing
+            setFocusAndSelection("focused", "c");
+          },
+        },
+      });
+      getWorkArea().innerHTML.should.equal(after);
+      assertFocusAndSelection("focused", "c");
     });
   });
 

--- a/test/restore-focus.js
+++ b/test/restore-focus.js
@@ -294,12 +294,12 @@ describe("Option to forcibly restore focus after morph", function () {
           <div>
             <input type="text" id="focused" value="abc">
             <input type="text" id="other">
-          </div>`
+          </div>`;
       const after = `
           <div>
             <input type="text" id="other">
             <input type="text" id="focused" value="abc">
-          </div>`
+          </div>`;
       setFocusAndSelection("focused", "b");
       Idiomorph.morph(getWorkArea(), after, {
         morphStyle: "innerHTML",


### PR DESCRIPTION
Found that when restoring focus selection we also need to check that the element doesn't already have a selection set before we update it because it is possible the user could have change the selection during the morph. so just checking the current selectionEnd is not valid before restoring the selection seems to fix the issue.

 Also found a bug where if the selection begins at the 0 position the if statement was treating 0 as false for selectionStart which prevents selection restoration.  We only need to verify the selectionEnd value is not 0 or undefined so just removed the selectionStart check.

Added a simulated test for updating selection during morph that was failing before the fix and also changed one of the other tests to have a selection starting at position 0.