### PR TITLE
Restore direct imports, and add named export for ESM htmx extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ the `dist/idiomorph-ext.js` file in your HTML:
 </div>
 ```
 
+or by importing the "idiomorph/htmx" module:
+
+```html
+import "idiomorph/htmx";
+```
+
 Note that this file includes both Idiomorph and the htmx extension.
 
 #### Configuring Morphing Behavior in htmx

--- a/package.json
+++ b/package.json
@@ -19,8 +19,12 @@
   "module": "dist/idiomorph.esm.js",
   "unpkg": "dist/idiomorph.min.js",
   "exports": {
-    "require": "./dist/idiomorph.cjs.js",
-    "import": "./dist/idiomorph.esm.js"
+    ".": {
+      "require": "./dist/idiomorph.cjs.js",
+      "import": "./dist/idiomorph.esm.js"
+    },
+    "./htmx": "./dist/idiomorph-ext.esm.js",
+    "./dist/*": "./dist/*"
   },
   "scripts": {
     "test": "web-test-runner",
@@ -34,7 +38,7 @@
     "perf": "node perf/runner.js",
     "amd": "(echo \"define(() => {\n\" && cat src/idiomorph.js && echo \"\nreturn Idiomorph});\") > dist/idiomorph.amd.js",
     "cjs": "(cat src/idiomorph.js && echo \"\nmodule.exports = Idiomorph;\") > dist/idiomorph.cjs.js",
-    "esm": "(cat src/idiomorph.js && echo \"\nexport {Idiomorph};\") > dist/idiomorph.esm.js",
+    "esm": "(cat src/idiomorph.js && echo \"\nexport {Idiomorph};\") > dist/idiomorph.esm.js && (echo \"import htmx from \\\"htmx.org\\\";\n\" && cat dist/idiomorph-ext.js && echo \"\nexport {Idiomorph};\") > dist/idiomorph-ext.esm.js",
     "gen-modules": "npm run-script amd && npm run-script cjs && npm run-script esm",
     "dist": "cp -r src/* dist/ && cat src/idiomorph.js src/idiomorph-htmx.js > dist/idiomorph-ext.js && npm run-script gen-modules && npm run-script uglify && gzip -9 -k -f dist/idiomorph.min.js > dist/idiomorph.min.js.gz && exit",
     "uglify": "uglifyjs -m eval -o dist/idiomorph.min.js dist/idiomorph.js && uglifyjs -m eval -o dist/idiomorph-ext.min.js dist/idiomorph-ext.js",


### PR DESCRIPTION
1. Fixes a regression in v0.7 where one could no longer import dist paths, e.g. `import "idiomorph/dist/idiomorph.esm.js"`
2. Adds an official export path for Idiomorph + htmx extension: `import "idiomorph/htmx"`

Closes #119
Closes #38 