### PR TITLE
Fix issue when using numeric ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Removed:
   * Remove AMD publish target since its EOL: https://github.com/requirejs/requirejs/issues/1816#issuecomment-707503323
 
+* Fixed:
+  * Fix error when morphing elements with numeric ids (@botandrose, @ksbrooksjr)
+
 ## [0.7.2] - 2025-02-20
 
 * Fixed:

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -548,8 +548,8 @@ var Idiomorph = (function () {
       const target =
         /** @type {Element} - will always be found */
         (
-          ctx.target.querySelector(`#${id}`) ||
-            ctx.pantry.querySelector(`#${id}`)
+          ctx.target.querySelector(`[id="${id}"]`) ||
+            ctx.pantry.querySelector(`[id="${id}"]`)
         );
       removeElementFromAncestorsIdMaps(target, ctx);
       moveBefore(parentNode, target, after);

--- a/test/core.js
+++ b/test/core.js
@@ -185,6 +185,13 @@ describe("Core morphing tests", function () {
     initial.outerHTML.should.equal(final.outerHTML);
   });
 
+  it("can handle numeric ids", function () {
+    let initial = make(`<div><hr id="1"></div>`);
+    let final = `<div><div><hr id="1"></div></div>`;
+    Idiomorph.morph(initial, final);
+    initial.outerHTML.should.equal(final);
+  });
+
   it("ignores active element when ignoreActive set to true", function () {
     let initialSource = "<div><div id='d1'>Foo</div><input id='i1'></div>";
     getWorkArea().innerHTML = initialSource;


### PR DESCRIPTION
As described in #123, its possible to use numeric ids, e.g. `<hr id="1">`, which is legal, but discouraged. Idiomorph assumes that all ids are valid CSS selectors when prepended with `#`, but `#1` is not a valid css selector, so we get a crash.

We can work around this by switching the selector from `#${id}` to `[id="${id}"]`, as suggested by @ksbrooksjr , and `npm run perf v0.7.2` on this branch shows no detectable difference in perf.

Closes #123 