### PR TITLE
[WIP] Fix issue with outerHTML morphing an IDed node that gets moved

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -548,7 +548,8 @@ var Idiomorph = (function () {
       const target =
         /** @type {Element} - will always be found */
         (
-          ctx.target.querySelector(`[id="${id}"]`) ||
+          (ctx.target.id === id && ctx.target) ||
+            ctx.target.querySelector(`[id="${id}"]`) ||
             ctx.pantry.querySelector(`[id="${id}"]`)
         );
       removeElementFromAncestorsIdMaps(target, ctx);

--- a/test/fidelity.js
+++ b/test/fidelity.js
@@ -77,6 +77,24 @@ describe("Tests to ensure that idiomorph merges properly", function () {
     );
   });
 
+  it("should wrap an IDed node", function () {
+    getWorkArea().innerHTML = `<hr id="a">`;
+    let initial = getWorkArea().firstElementChild;
+    let finalSrc = `<div><hr id="a"></div>`;
+    let ret = Idiomorph.morph(initial, finalSrc);
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    // ret.map(e=>e.outerHTML).should.eql([finalSrc]);
+  });
+
+  it("should wrap an anonymous node", function () {
+    getWorkArea().innerHTML = `<hr>`;
+    let initial = getWorkArea().firstElementChild;
+    let finalSrc = `<div><hr></div>`;
+    let ret = Idiomorph.morph(initial, finalSrc);
+    getWorkArea().innerHTML.should.equal(finalSrc);
+    // ret.map(e=>e.outerHTML).should.eql([finalSrc]);
+  });
+
   it("should append a node", function () {
     testFidelity("<main></main>", "<main><p>hello you</p></main>");
   });


### PR DESCRIPTION
## Summary

While fixing another bug, I stumbled upon a corner case issue. Consider the following situation:
1. Root node is IDed
2. Root node gets moved
3. outerHTML morph style
4. Root node is part of the document and gets a fake duck-typed parent node because of 3

When all of the above are true, a type error is raised: `TypeError: Cannot read properties of null (reading 'id') at removeElementFromAncestorsIdMaps`

## Example
`<hr id="a">` =>  `<div><hr id="a"></div>`
The first commit has this in a failing test.

## WIP Analysis
1. The error raises because `moveBeforeById` fails to consider the case where the `ctx.target` is the IDed node to move.
2. Fixing that issue (second commit here) results in an incorrect morph, due to the hacky nature of the duck-typed parent node.
3. ???
4. Profit!