### PR TITLE
Fix restoreFocus when focus is lost on an element with a numeric id

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -236,7 +236,7 @@ var Idiomorph = (function () {
     const results = fn();
 
     if (activeElementId && activeElementId !== document.activeElement?.id) {
-      activeElement = ctx.target.querySelector(`#${activeElementId}`);
+      activeElement = ctx.target.querySelector(`[id="${activeElementId}"]`);
       activeElement?.focus();
     }
     if (activeElement && !activeElement.selectionEnd && selectionEnd) {

--- a/test/restore-focus.js
+++ b/test/restore-focus.js
@@ -651,6 +651,25 @@ describe("Option to forcibly restore focus after morph", function () {
       assertFocus("focused");
     });
 
+    it("restores focus state with reparented numeric id", function () {
+      assertFocusPreservationWithoutMoveBefore(
+        `
+        <div>
+          <input type="text" id="other">
+          <div>
+            <input type="text" id="1" value="abc">
+          </div>
+        </div>`,
+        `
+        <div>
+          <input type="text" id="other">
+          <input type="text" id="1" value="abc">
+        </div>`,
+        "1",
+        "b",
+      );
+    });
+
     it("preserves focus state when focused element is moved between anonymous containers", function () {
       assertFocusPreservationWithoutMoveBefore(
         `


### PR DESCRIPTION
Following up on #125, I found another place in the code where we were assuming that it was safe to prepend `#` to an ID and have a valid CSS selector: the focus restoration code.

First commit is a failing test to expose the issue, and the second is the same fix as applied in #125. 