### PR TITLE
Fix persistence bug caused by untrustworthy HTMLFormElement.id getter

### DIFF
--- a/test/fidelity.js
+++ b/test/fidelity.js
@@ -156,4 +156,14 @@ describe("Tests to ensure that idiomorph merges properly", function () {
 
     element.outerHTML.should.equal(finalSrc);
   });
+
+  it("issue https://github.com/bigskysoftware/idiomorph/issues/135", function () {
+    // inputs with name="id" make their form's id property unreliable!
+    // form.id returns the <input>, not "myForm", breaking idiomorph's element persistence
+    let src = `<form id="myForm"><input name="id"></form>`;
+    getWorkArea().innerHTML = src;
+    let element = getWorkArea().querySelector("form");
+    Idiomorph.morph(getWorkArea(), src, { morphStyle: "innerHTML" });
+    should.equal(element, getWorkArea().querySelector("form"));
+  });
 });


### PR DESCRIPTION
Turns out we can't simply call `.id` on element nodes, because that property is unreliable on `<form>` and `<fieldset>` elements. It could return the id of the node as expected, OR (problematically) a child element that has a name attribute of `id`. The latter breaks persistence of the form element, which can have further consequences involving lost state.

This PR has two commits:
1. A failing test exposing the issue
2. A commit that fixes it, but at the cost of a 5% perf hit on my machine.

I'm marking this PR as WIP in the hopes I can find a faster way to resolve this.

For more information, see: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement#issues_with_naming_elements
Fixes #135