### PR TITLE
[WIP] Remove performance bottleneck in active element preservation

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -1047,9 +1047,12 @@ var Idiomorph = (function () {
       /** @type {Element[]} */
       let activeElementAndParents = [];
       let elt = document.activeElement;
-      while (elt && elt !== oldNode) {
-        activeElementAndParents.push(elt);
-        elt = elt.parentElement;
+      if (elt?.tagName !== "BODY" && oldNode.contains(elt)) {
+        while (elt) {
+          activeElementAndParents.push(elt);
+          if (elt === oldNode) break;
+          elt = elt.parentElement;
+        }
       }
       return activeElementAndParents;
     }

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -112,6 +112,7 @@ var Idiomorph = (function () {
    * @property {ConfigInternal['callbacks']} callbacks
    * @property {ConfigInternal['head']} head
    * @property {HTMLDivElement} pantry
+   * @property {Element[]} activeElementAndParents
    */
 
   //=============================================================================
@@ -424,7 +425,8 @@ var Idiomorph = (function () {
 
           // if the current node contains active element, stop looking for better future matches,
           // because if one is found, this node will be moved to the pantry, reparenting it and thus losing focus
-          if (cursor.contains(document.activeElement)) break;
+          // @ts-ignore pretend cursor is Element rather than Node, we're just testing for array inclusion
+          if (ctx.activeElementAndParents.includes(cursor)) break;
 
           cursor = cursor.nextSibling;
         }
@@ -996,6 +998,7 @@ var Idiomorph = (function () {
         idMap: idMap,
         persistentIds: persistentIds,
         pantry: createPantry(),
+        activeElementAndParents: createActiveElementAndParents(oldNode),
         callbacks: mergedConfig.callbacks,
         head: mergedConfig.head,
       };
@@ -1034,6 +1037,21 @@ var Idiomorph = (function () {
       pantry.hidden = true;
       document.body.insertAdjacentElement("afterend", pantry);
       return pantry;
+    }
+
+    /**
+     * @param {Element} oldNode
+     * @returns {Element[]}
+     */
+    function createActiveElementAndParents(oldNode) {
+      /** @type {Element[]} */
+      let activeElementAndParents = [];
+      let elt = document.activeElement;
+      while (elt && elt !== oldNode) {
+        activeElementAndParents.push(elt);
+        elt = elt.parentElement;
+      }
+      return activeElementAndParents;
     }
 
     /**


### PR DESCRIPTION
It turns out that `Element.contains` is really slow, so we get a big perf win by precomputing the active element parent path and doing an array inclusion check instead.

I'm marking this PR as WIP because I want to add a benchmark for this before merging. None of the existing perf benchmark have active elements, so they don't really capture the slowdown. But considering how impactful this seems to be, a benchmark seems like a good idea. It's about an order of magnitude in my BARD Tracker app!

Funny enough, though, I'm already seeing perf increases of around 10-35% in the existing benchmarks, even though they don't contain any active elements!

Closes #134