### PR TITLE
Log warning in console if duplicate ids are detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   * Remove AMD publish target since its EOL: https://github.com/requirejs/requirejs/issues/1816#issuecomment-707503323
   * Remove CommonJS publish target. `require("idiomorph")` no longer resolves; use `import "idiomorph"` instead. (@botandrose) #122
 
+* Added:
+  * Warn in the console when duplicate ids are detected during a morph, since they can cause subtle state loss (@botandrose) #142
+
 ## [0.7.4] - 2025-09-29
 
 * Fixed:

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -1182,6 +1182,12 @@ var Idiomorph = (function () {
       for (const id of duplicateIds) {
         persistentIds.delete(id);
       }
+      if (duplicateIds.size) {
+        console.warn(
+          "[Warning] duplicate ids found during morph, state loss within these elements is possible:",
+          Array.from(duplicateIds),
+        );
+      }
       return persistentIds;
     }
 

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -1189,6 +1189,12 @@ var Idiomorph = (function () {
       for (const id of duplicateIds) {
         persistentIds.delete(id);
       }
+      if (duplicateIds.size) {
+        console.warn(
+          "[Warning] duplicate ids found during morph, state loss within these elements is possible:",
+          Array.from(duplicateIds),
+        );
+      }
       return persistentIds;
     }
 

--- a/test/core.js
+++ b/test/core.js
@@ -606,4 +606,50 @@ describe("Core morphing tests", function () {
     // included in the persistent ID set or it will pantry the id'ed node in error
     initial.outerHTML.should.equal("<span>Bar</span>");
   });
+
+  describe("duplicate id warnings", function () {
+    let warn;
+
+    beforeEach(function () {
+      warn = sinon.stub(console, "warn");
+    });
+
+    afterEach(function () {
+      warn.restore();
+    });
+
+    it("warns when the old content has duplicate ids", function () {
+      let initial = make("<div><p id='a'>Foo</p><p id='a'>Bar</p></div>");
+      Idiomorph.morph(initial, "<div><p id='a'>Baz</p></div>");
+      warn.calledOnce.should.equal(true);
+      warn.firstCall.args[1].should.eql(["a"]);
+    });
+
+    it("warns when the new content has duplicate ids", function () {
+      let initial = make("<div><p id='a'>Foo</p></div>");
+      Idiomorph.morph(initial, "<div><p id='a'>Bar</p><p id='a'>Baz</p></div>");
+      warn.calledOnce.should.equal(true);
+      warn.firstCall.args[1].should.eql(["a"]);
+    });
+
+    it("reports every duplicated id", function () {
+      let initial = make(
+        "<div><p id='a'>Foo</p><p id='a'>Bar</p><p id='b'>Baz</p><p id='b'>Qux</p></div>",
+      );
+      Idiomorph.morph(initial, "<div><p id='a'>Foo</p><p id='b'>Baz</p></div>");
+      warn.firstCall.args[1].should.eql(["a", "b"]);
+    });
+
+    it("does not warn when all ids are unique", function () {
+      let initial = make("<div><p id='a'>Foo</p><p id='b'>Bar</p></div>");
+      Idiomorph.morph(initial, "<div><p id='a'>Baz</p><p id='b'>Qux</p></div>");
+      warn.called.should.equal(false);
+    });
+
+    it("does not warn when the content has no ids at all", function () {
+      let initial = make("<div><p>Foo</p><p>Bar</p></div>");
+      Idiomorph.morph(initial, "<div><p>Baz</p><p>Qux</p></div>");
+      warn.called.should.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
## Background 
Idiomorph relies on ids being unique within the morphed document for two main reasons:

1. It knows how to match up the old and new content
2. It ensure elements with hidden state are reused, and thus retain their hidden state.

## Problem
It's not easy to know when your html documents have duplicate ids, and resultant failures in the morph may be subtle or non-obvious in cause. It would likely take a deep dive into Idiomorph's algorithm with a debugger to identify that the problem is duplicate ids.

## Proposition
Idiomorph already knows on startup when you have duplicate ids, so this PR simply prints a warning to the console with a list of them, leaving it up to the user to decide to either address or ignore. I've tried to make the message generic, so that vicarious users of Idiomorph (e.g. Turbo) who may have never heard it can still understand what the problem is, and what to do.

## Questions
1. Do we want to add some kind of option for users to disable this warning?
2. Can we improve the warning message? Maybe link to a document explaining the issue in more detail?
3. Any reason not to do this?

Closes #141 