### PR TITLE
Skip beforeAttributeUpdated when an attribute value is unchanged

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -676,12 +676,13 @@ var Idiomorph = (function () {
         const oldAttributes = oldElt.attributes;
         const newAttributes = newElt.attributes;
         for (const newAttribute of newAttributes) {
+          if (oldElt.getAttribute(newAttribute.name) === newAttribute.value) {
+            continue;
+          }
           if (ignoreAttribute(newAttribute.name, oldElt, "update", ctx)) {
             continue;
           }
-          if (oldElt.getAttribute(newAttribute.name) !== newAttribute.value) {
-            oldElt.setAttribute(newAttribute.name, newAttribute.value);
-          }
+          oldElt.setAttribute(newAttribute.name, newAttribute.value);
         }
         // iterate backwards to avoid skipping over items when a delete occurs
         for (let i = oldAttributes.length - 1; 0 <= i; i--) {

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -235,6 +235,34 @@ describe("lifecycle hooks", function () {
     initial.outerHTML.should.equal(`<a href="#"></a>`);
   });
 
+  it("does not call beforeAttributeUpdated when the attribute value is unchanged", function () {
+    let calls = [];
+    let initial = make(`<a href="#" id="x" class="y"></a>`);
+    Idiomorph.morph(initial, `<a href="#" id="x" class="y"></a>`, {
+      callbacks: {
+        beforeAttributeUpdated: (attributeName, node, mutationType) => {
+          calls.push([attributeName, mutationType]);
+        },
+      },
+    });
+    initial.outerHTML.should.equal(`<a href="#" id="x" class="y"></a>`);
+    calls.should.eql([]);
+  });
+
+  it("calls beforeAttributeUpdated only for attributes that actually change", function () {
+    let calls = [];
+    let initial = make(`<a href="a" id="x" class="y"></a>`);
+    Idiomorph.morph(initial, `<a href="b" id="x" class="y"></a>`, {
+      callbacks: {
+        beforeAttributeUpdated: (attributeName, node, mutationType) => {
+          calls.push([attributeName, mutationType]);
+        },
+      },
+    });
+    initial.outerHTML.should.equal(`<a href="b" id="x" class="y"></a>`);
+    calls.should.eql([["href", "update"]]);
+  });
+
   it("hooks work as expected", function () {
     let beginSrc = `
             <div>


### PR DESCRIPTION
This is a small optimization that can significantly reduces morph time on dense pages without changing semantics to consumers.

`morphAttributes` calls the `beforeAttributeUpdated` callback for every attribute on every element being morphed, before checking whether the new value differs from the existing one. This PR changes it to trigger the callback only when the new and old values differ.

From what I read in abf6c94, the callback's purpose is to allow consumers to ignore changes to attributes - when the values are the same there is nothing to prevent.

