### PR TITLE
Fix TypeError in saveAndRestoreFocus when restored id resolves to a non-input element

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -230,11 +230,27 @@ var Idiomorph = (function () {
       activeElementId &&
       activeElementId !== document.activeElement?.getAttribute("id")
     ) {
-      activeElement = ctx.target.querySelector(`[id="${activeElementId}"]`);
+      const candidate = ctx.target.querySelector(`[id="${activeElementId}"]`);
+      // the re-queried element may not be an input/textarea even if the
+      // original was, since any element can share the saved id
+      activeElement =
+        candidate instanceof HTMLInputElement ||
+        candidate instanceof HTMLTextAreaElement
+          ? candidate
+          : null;
       activeElement?.focus();
     }
-    if (activeElement && !activeElement.selectionEnd && selectionEnd) {
-      activeElement.setSelectionRange(selectionStart, selectionEnd);
+    if (
+      activeElement &&
+      typeof activeElement.setSelectionRange === "function" &&
+      !activeElement.selectionEnd &&
+      selectionEnd
+    ) {
+      try {
+        activeElement.setSelectionRange(selectionStart, selectionEnd);
+      } catch {
+        // setSelectionRange throws on input types that don't support text selection
+      }
     }
 
     return results;

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -230,26 +230,16 @@ var Idiomorph = (function () {
       activeElementId &&
       activeElementId !== document.activeElement?.getAttribute("id")
     ) {
-      const candidate = ctx.target.querySelector(`[id="${activeElementId}"]`);
-      // the re-queried element may not be an input/textarea even if the
-      // original was, since any element can share the saved id
-      activeElement =
-        candidate instanceof HTMLInputElement ||
-        candidate instanceof HTMLTextAreaElement
-          ? candidate
-          : null;
+      activeElement = ctx.target.querySelector(`[id="${activeElementId}"]`);
       activeElement?.focus();
     }
-    if (
-      activeElement &&
-      typeof activeElement.setSelectionRange === "function" &&
-      !activeElement.selectionEnd &&
-      selectionEnd
-    ) {
+    if (activeElement && !activeElement.selectionEnd && selectionEnd) {
       try {
         activeElement.setSelectionRange(selectionStart, selectionEnd);
       } catch {
-        // setSelectionRange throws on input types that don't support text selection
+        // the element may not support setSelectionRange: it's no longer an
+        // input/textarea after the morph, or it's an input type (number,
+        // email, date, ...) that doesn't support text selection
       }
     }
 

--- a/test/restore-focus.js
+++ b/test/restore-focus.js
@@ -289,6 +289,53 @@ describe("Option to forcibly restore focus after morph", function () {
       assertNoFocus();
     });
 
+    it("does not throw if the saved id resolves to a non-input element after morph", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <input type="text" id="focused" value="abc">
+        </div>`;
+      setFocusAndSelection("focused", "b");
+
+      // after the morph nothing input-like has id="focused"; a <div> does
+      const after = `
+        <div>
+          <div id="focused">replaced</div>
+        </div>`;
+      (function () {
+        Idiomorph.morph(getWorkArea(), after, {
+          morphStyle: "innerHTML",
+          restoreFocus: true,
+        });
+      }).should.not.throw();
+
+      getWorkArea().innerHTML.should.equal(after);
+      assertNoFocus();
+    });
+
+    it("does not throw for input types that reject setSelectionRange", function () {
+      getWorkArea().innerHTML = `
+        <div>
+          <input type="number" id="focused" value="123">
+          <input type="number" id="other">
+        </div>`;
+      // type=number does not support selection, so set focus only
+      setFocus("focused");
+
+      const after = `
+        <div>
+          <input type="number" id="other">
+          <input type="number" id="focused" value="123">
+        </div>`;
+      (function () {
+        Idiomorph.morph(getWorkArea(), after, {
+          morphStyle: "innerHTML",
+          restoreFocus: true,
+        });
+      }).should.not.throw();
+
+      getWorkArea().innerHTML.should.equal(after);
+    });
+
     it("does not restore selection if selection still set or changed", function () {
       getWorkArea().innerHTML = `
           <div>


### PR DESCRIPTION
## Problem

`saveAndRestoreFocus` can throw `TypeError: activeElement.setSelectionRange is not a function` during a morph.

After the morph, the function re-queries the previously-focused element by its saved id:

  ```js
  activeElement = ctx.target.querySelector(`[id="${activeElementId}"]`);
```

It then calls `activeElement.setSelectionRange(...)`. Two problems compound here:

1. querySelector returns Element | null — any element sharing that id matches  (div, span, button, …). The instanceof `HTMLInputElement | HTMLTextAreaElement`  guard at the top of the function is only applied to the pre-morph element and is never  re-applied after the re-query.

2. `setSelectionRange` is called with no support check. The existing !activeElement.selectionEnd guard does not protect against non-inputs, since selectionEnd is undefined on them (making !undefined truthy).

Additionally, setSelectionRange throws InvalidStateError on real inputs whose type doesn't support text selection (number, email, date, …).

This is reachable from any morph where a focused input's id no longer maps to an input-like element in the new DOM. It surfaced in the wild via Turbo's morph refresh method (<turbo-stream action="refresh">), where auto-generated input ids are common. The morph still completes, but it produces a noisy unhandled promise rejection.

## Fix

- Re-apply the input/textarea instanceof check after the re-query; fall back to null otherwise.
- Feature-detect setSelectionRange and wrap the call in try/catch to absorb the InvalidStateError thrown by non-selectable input types.

## Tests

Added two cases to test/restore-focus.js:

- saved id resolves to a `div` after morph — reproduces the exact TypeError on main and passes with the fix.
- focused type=number input — guards the unsupported-type path.