### PR TITLE
Recognize nodes from other realms via realm-safe type checks

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -136,15 +136,15 @@ var Idiomorph = (function () {
   //=============================================================================
 
   /**
-   * @param {any} value
+   * @param {unknown} value
    * @returns {value is Node}
    */
   function isNode(value) {
-    return typeof value?.nodeType === "number";
+    return typeof (/** @type {any} */ (value)?.nodeType) === "number";
   }
 
   /**
-   * @param {any} value
+   * @param {Node | null | undefined} value
    * @returns {value is Element}
    */
   function isElement(value) {
@@ -152,51 +152,66 @@ var Idiomorph = (function () {
   }
 
   /**
-   * @param {any} value
+   * @param {Node | null | undefined} value
    * @returns {value is Document}
    */
   function isDocument(value) {
     return value?.nodeType === Node.DOCUMENT_NODE;
   }
 
+  const HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
+
   /**
-   * @param {any} value
+   * @param {Node | null | undefined} value
+   * @param {string} localName
+   * @returns {value is Element}
+   */
+  function isHtmlElement(value, localName) {
+    return (
+      isElement(value) &&
+      value.localName === localName &&
+      value.namespaceURI === HTML_NAMESPACE
+    );
+  }
+
+  /**
+   * @param {Node | null | undefined} value
    * @returns {value is HTMLTemplateElement}
    */
   function isTemplateElement(value) {
-    return isElement(value) && value.localName === "template";
+    return isHtmlElement(value, "template");
   }
 
   /**
-   * @param {any} value
+   * @param {Node | null | undefined} value
    * @returns {value is HTMLHeadElement}
    */
   function isHeadElement(value) {
-    return isElement(value) && value.localName === "head";
+    return isHtmlElement(value, "head");
   }
 
   /**
-   * @param {any} value
+   * @param {Node | null | undefined} value
    * @returns {value is HTMLInputElement}
    */
   function isInputElement(value) {
-    return isElement(value) && value.localName === "input";
+    return isHtmlElement(value, "input");
   }
 
   /**
-   * @param {any} value
+   * @param {Node | null | undefined} value
    * @returns {value is HTMLOptionElement}
    */
   function isOptionElement(value) {
-    return isElement(value) && value.localName === "option";
+    return isHtmlElement(value, "option");
   }
 
   /**
-   * @param {any} value
+   * @param {Node | null | undefined} value
    * @returns {value is HTMLTextAreaElement}
    */
   function isTextAreaElement(value) {
-    return isElement(value) && value.localName === "textarea";
+    return isHtmlElement(value, "textarea");
   }
   /**
    * Default configuration values, updatable by users now

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -124,6 +124,80 @@ var Idiomorph = (function () {
   //=============================================================================
 
   const noOp = () => {};
+
+  //=============================================================================
+  // Realm-safe node type checks.
+  //
+  // `instanceof Node` (and friends) fails for nodes created in another JS
+  // realm (e.g. an iframe's document), even after they are adopted into this
+  // document, because each realm has its own constructors. These helpers
+  // duck-type nodes via `nodeType` and `localName` instead, so nodes from any
+  // realm are recognized.
+  //=============================================================================
+
+  /**
+   * @param {any} value
+   * @returns {value is Node}
+   */
+  function isNode(value) {
+    return typeof value?.nodeType === "number";
+  }
+
+  /**
+   * @param {any} value
+   * @returns {value is Element}
+   */
+  function isElement(value) {
+    return value?.nodeType === Node.ELEMENT_NODE;
+  }
+
+  /**
+   * @param {any} value
+   * @returns {value is Document}
+   */
+  function isDocument(value) {
+    return value?.nodeType === Node.DOCUMENT_NODE;
+  }
+
+  /**
+   * @param {any} value
+   * @returns {value is HTMLTemplateElement}
+   */
+  function isTemplateElement(value) {
+    return isElement(value) && value.localName === "template";
+  }
+
+  /**
+   * @param {any} value
+   * @returns {value is HTMLHeadElement}
+   */
+  function isHeadElement(value) {
+    return isElement(value) && value.localName === "head";
+  }
+
+  /**
+   * @param {any} value
+   * @returns {value is HTMLInputElement}
+   */
+  function isInputElement(value) {
+    return isElement(value) && value.localName === "input";
+  }
+
+  /**
+   * @param {any} value
+   * @returns {value is HTMLOptionElement}
+   */
+  function isOptionElement(value) {
+    return isElement(value) && value.localName === "option";
+  }
+
+  /**
+   * @param {any} value
+   * @returns {value is HTMLTextAreaElement}
+   */
+  function isTextAreaElement(value) {
+    return isElement(value) && value.localName === "textarea";
+  }
   /**
    * Default configuration values, updatable by users now
    * @type {ConfigInternal}
@@ -286,10 +360,7 @@ var Idiomorph = (function () {
       endPoint = null,
     ) {
       // normalize
-      if (
-        oldParent instanceof HTMLTemplateElement &&
-        newParent instanceof HTMLTemplateElement
-      ) {
+      if (isTemplateElement(oldParent) && isTemplateElement(newParent)) {
         // @ts-ignore we can pretend the DocumentFragment is an Element
         oldParent = oldParent.content;
         // @ts-ignore ditto
@@ -319,7 +390,7 @@ var Idiomorph = (function () {
         }
 
         // if the matching node is elsewhere in the original content
-        if (newChild instanceof Element) {
+        if (isElement(newChild)) {
           // we can pretend the id is non-null because the next `.has` line will reject it if not
           const newChildId = /** @type {String} */ (
             newChild.getAttribute("id")
@@ -647,12 +718,9 @@ var Idiomorph = (function () {
         return oldNode;
       }
 
-      if (oldNode instanceof HTMLHeadElement && ctx.head.style === "none") {
+      if (isHeadElement(oldNode) && ctx.head.style === "none") {
         // ignore the head element
-      } else if (
-        oldNode instanceof HTMLHeadElement &&
-        ctx.head.style !== "morph"
-      ) {
+      } else if (isHeadElement(oldNode) && ctx.head.style !== "morph") {
         // ok to cast: if newContent wasn't also a <head>, it would've got caught in the `!isSoftMatch` branch above
         handleHeadElement(
           oldNode,
@@ -742,8 +810,8 @@ var Idiomorph = (function () {
      */
     function syncInputValue(oldElement, newElement, ctx) {
       if (
-        oldElement instanceof HTMLInputElement &&
-        newElement instanceof HTMLInputElement &&
+        isInputElement(oldElement) &&
+        isInputElement(newElement) &&
         newElement.type !== "file"
       ) {
         let newValue = newElement.value;
@@ -766,14 +834,11 @@ var Idiomorph = (function () {
         }
         // TODO: QUESTION(1cg): this used to only check `newElement` unlike the other branches -- why?
         // did I break something?
-      } else if (
-        oldElement instanceof HTMLOptionElement &&
-        newElement instanceof HTMLOptionElement
-      ) {
+      } else if (isOptionElement(oldElement) && isOptionElement(newElement)) {
         syncBooleanAttribute(oldElement, newElement, "selected", ctx);
       } else if (
-        oldElement instanceof HTMLTextAreaElement &&
-        newElement instanceof HTMLTextAreaElement
+        isTextAreaElement(oldElement) &&
+        isTextAreaElement(newElement)
       ) {
         let newValue = newElement.value;
         let oldValue = oldElement.value;
@@ -1241,7 +1306,7 @@ var Idiomorph = (function () {
      * @returns {Element}
      */
     function normalizeElement(content) {
-      if (content instanceof Document) {
+      if (isDocument(content)) {
         return content.documentElement;
       } else {
         // a Text or Comment node is not an Element, but morphOuterHTML only ever reads Node members off it
@@ -1264,7 +1329,7 @@ var Idiomorph = (function () {
       ) {
         // the template tag created by idiomorph parsing can serve as a dummy parent
         return /** @type {Element} */ (newContent);
-      } else if (newContent instanceof Node) {
+      } else if (isNode(newContent)) {
         if (newContent.parentNode) {
           // we can't use the parent directly because newContent may have siblings
           // that we don't want in the morph, and reparenting might be expensive (TODO is it?),
@@ -1324,7 +1389,7 @@ var Idiomorph = (function () {
        */
       querySelectorAll(selector) {
         return this.childNodes.reduce((results, node) => {
-          if (node instanceof Element) {
+          if (isElement(node)) {
             if (node.matches(selector)) results.push(node);
             const nodeList = node.querySelectorAll(selector);
             for (let i = 0; i < nodeList.length; i++) {

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -302,18 +302,15 @@ var Idiomorph = (function () {
    */
   function saveAndRestoreFocus(ctx, fn) {
     if (!ctx.config.restoreFocus) return fn();
+    // focus lives in the target's document, which may not be ours
+    const doc = ctx.target.ownerDocument;
     let activeElement =
       /** @type {HTMLInputElement|HTMLTextAreaElement|null} */ (
-        document.activeElement
+        doc.activeElement
       );
 
     // don't bother if the active element is not an input or textarea
-    if (
-      !(
-        activeElement instanceof HTMLInputElement ||
-        activeElement instanceof HTMLTextAreaElement
-      )
-    ) {
+    if (!(isInputElement(activeElement) || isTextAreaElement(activeElement))) {
       return fn();
     }
 
@@ -323,7 +320,7 @@ var Idiomorph = (function () {
 
     if (
       activeElementId &&
-      activeElementId !== document.activeElement?.getAttribute("id")
+      activeElementId !== doc.activeElement?.getAttribute("id")
     ) {
       activeElement = ctx.target.querySelector(
         `[id="${CSS.escape(activeElementId)}"]`,

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -140,7 +140,10 @@ var Idiomorph = (function () {
    * @returns {value is Node}
    */
   function isNode(value) {
-    return typeof (/** @type {any} */ (value)?.nodeType) === "number";
+    return (
+      value instanceof Node ||
+      typeof (/** @type {any} */ (value)?.nodeType) === "number"
+    );
   }
 
   /**
@@ -148,7 +151,7 @@ var Idiomorph = (function () {
    * @returns {value is Element}
    */
   function isElement(value) {
-    return value?.nodeType === Node.ELEMENT_NODE;
+    return value instanceof Element || value?.nodeType === Node.ELEMENT_NODE;
   }
 
   /**
@@ -156,7 +159,7 @@ var Idiomorph = (function () {
    * @returns {value is Document}
    */
   function isDocument(value) {
-    return value?.nodeType === Node.DOCUMENT_NODE;
+    return value instanceof Document || value?.nodeType === Node.DOCUMENT_NODE;
   }
 
   const HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";

--- a/test/core.js
+++ b/test/core.js
@@ -1,5 +1,12 @@
 describe("Core morphing tests", function () {
   setup();
+  function makeForeign(htmlStr) {
+    let iframe = document.createElement("iframe");
+    getWorkArea().append(iframe);
+    let container = iframe.contentDocument.createElement("div");
+    container.innerHTML = htmlStr;
+    return container.firstElementChild;
+  }
 
   it("morphs outerHTML by default", function () {
     let initial = make("<button>Foo</button>");
@@ -58,6 +65,106 @@ describe("Core morphing tests", function () {
     let final = [...make(finalSrc).children];
     Idiomorph.morph(initial, final, { morphStyle: "outerHTML" });
     initial.outerHTML.should.equal("<button>Bar</button>");
+  });
+
+  it("morphs outerHTML as content properly when argument is a node from another document", function () {
+    let initial = make("<button>Foo</button>");
+    let iframe = document.createElement("iframe");
+    getWorkArea().append(iframe);
+    let final = iframe.contentDocument.createElement("button");
+    final.textContent = "Bar";
+    Idiomorph.morph(initial, final, { morphStyle: "outerHTML" });
+    initial.outerHTML.should.equal("<button>Bar</button>");
+  });
+
+  it("syncs input value when newContent is a node from another document", function () {
+    let initial = make('<input type="text">');
+    initial.value = "Foo";
+    let iframe = document.createElement("iframe");
+    getWorkArea().append(iframe);
+    let final = iframe.contentDocument.createElement("input");
+    final.setAttribute("type", "text");
+    final.setAttribute("value", "Bar");
+    Idiomorph.morph(initial, final, { morphStyle: "outerHTML" });
+    initial.value.should.equal("Bar");
+  });
+
+  it("preserves id'd element when detached newContent is from another document", function () {
+    let initial = make(`<div><span id="s">Foo</span></div>`);
+    let span = initial.querySelector("span");
+    let final = makeForeign(`<div><div><span id="s">Foo</span></div></div>`);
+    final.remove();
+    Idiomorph.morph(initial, final);
+    initial.outerHTML.should.equal(
+      `<div><div><span id="s">Foo</span></div></div>`,
+    );
+    initial.querySelector("span").should.equal(span);
+  });
+
+  it("preserves id'd element when attached newContent is from another document", function () {
+    let initial = make(`<div><span id="s">Foo</span></div>`);
+    let span = initial.querySelector("span");
+    let final = makeForeign(`<div><div><span id="s">Foo</span></div></div>`);
+
+    Idiomorph.morph(initial, final);
+    initial.outerHTML.should.equal(
+      `<div><div><span id="s">Foo</span></div></div>`,
+    );
+    initial.querySelector("span").should.equal(span);
+  });
+
+  it("morphs template tag contents when newContent is from another document", function () {
+    let initial = make("<template data-old>Foo</template>");
+    let final = makeForeign("<template data-new>Bar</template>");
+    Idiomorph.morph(initial, final);
+    initial.outerHTML.should.equal('<template data-new="">Bar</template>');
+  });
+
+  it("syncs option selectedness when newContent is from another document", function () {
+    let parent = make(
+      `<div><select><option>0</option><option>1</option></select></div>`,
+    );
+    getWorkArea().append(parent);
+    let select = parent.querySelector("select");
+    let final = makeForeign(
+      `<select><option>0</option><option>1</option></select>`,
+    );
+    final.children[1].selected = true;
+    Idiomorph.morph(select, final);
+    select.selectedIndex.should.equal(1);
+  });
+
+  it("syncs textarea value when newContent is from another document", function () {
+    let initial = make("<textarea>Foo</textarea>");
+    initial.value = "dirty";
+    let final = makeForeign("<textarea>Bar</textarea>");
+    Idiomorph.morph(initial, final);
+    initial.value.should.equal("Bar");
+  });
+
+  it("ignores head element from another document when head.style is none", function () {
+    let iframe = document.createElement("iframe");
+    getWorkArea().append(iframe);
+    let foreignDocument = iframe.contentDocument;
+    foreignDocument.title = "Old";
+    let newHead = foreignDocument.createElement("head");
+    newHead.innerHTML = "<title>New</title>";
+    Idiomorph.morph(foreignDocument.head, newHead, {
+      head: { style: "none" },
+    });
+    foreignDocument.title.should.equal("Old");
+  });
+
+  it("morphs a document from another realm properly", function () {
+    let iframe = document.createElement("iframe");
+    getWorkArea().append(iframe);
+    let foreignDocument = iframe.contentDocument;
+    foreignDocument.body.innerHTML = "<p>Foo</p>";
+    Idiomorph.morph(
+      foreignDocument,
+      "<html><head></head><body><p>Bar</p></body></html>",
+    );
+    foreignDocument.body.innerHTML.should.equal("<p>Bar</p>");
   });
 
   it("morphs outerHTML as content properly when argument is HTMLElementCollection with siblings", function () {

--- a/test/core.js
+++ b/test/core.js
@@ -67,6 +67,17 @@ describe("Core morphing tests", function () {
     initial.outerHTML.should.equal("<button>Bar</button>");
   });
 
+  it("recognizes newContent as a node even when a child input shadows its properties", function () {
+    let parent = make('<div><form><input name="nodeType"></form></div>');
+    let final = make(
+      '<form><input name="nodeType"><input name="other"></form>',
+    );
+    Idiomorph.morph(parent, final, { morphStyle: "innerHTML" });
+    parent.innerHTML.should.equal(
+      '<form><input name="nodeType"><input name="other"></form>',
+    );
+  });
+
   it("morphs outerHTML as content properly when argument is a node from another document", function () {
     let initial = make("<button>Foo</button>");
     let iframe = document.createElement("iframe");

--- a/test/core.js
+++ b/test/core.js
@@ -142,6 +142,27 @@ describe("Core morphing tests", function () {
     initial.value.should.equal("Bar");
   });
 
+  it("morphs children of an SVG-namespace template element normally", function () {
+    let initial = make("<div><svg><template><g></g></template></svg></div>");
+    let finalSrc = "<div><svg><template><rect></rect></template></svg></div>";
+    Idiomorph.morph(initial, finalSrc);
+    initial.outerHTML.should.equal(finalSrc);
+  });
+
+  it("morphs non-HTML-namespace head elements normally", function () {
+    let parse = (str) =>
+      new DOMParser().parseFromString(str, "text/xml").documentElement;
+    let initial = parse(
+      '<opml><head lang="a"><title>Old</title></head></opml>',
+    );
+    let final = parse('<opml><head lang="b"><title>New</title></head></opml>');
+    Idiomorph.morph(initial.firstChild, final.firstChild, {
+      morphStyle: "outerHTML",
+    });
+    initial.firstChild.getAttribute("lang").should.equal("b");
+    initial.firstChild.firstChild.textContent.should.equal("New");
+  });
+
   it("ignores head element from another document when head.style is none", function () {
     let iframe = document.createElement("iframe");
     getWorkArea().append(iframe);

--- a/test/restore-focus.js
+++ b/test/restore-focus.js
@@ -21,6 +21,28 @@ describe("Option to forcibly restore focus after morph", function () {
   }
 
   describe("defaults to on", function () {
+    it("restores focus and selection state when morphing inside another document", function () {
+      let iframe = document.createElement("iframe");
+      getWorkArea().append(iframe);
+      let foreignDocument = iframe.contentDocument;
+      foreignDocument.body.innerHTML = `<input type="text" id="focused" value="abc"><input type="text" id="other">`;
+      let input = foreignDocument.getElementById("focused");
+      input.focus();
+      input.setSelectionRange(1, 2);
+      foreignDocument.body.moveBefore = undefined;
+
+      Idiomorph.morph(
+        foreignDocument.body,
+        `<input type="text" id="other"><input type="text" id="focused" value="abc">`,
+        { morphStyle: "innerHTML" },
+      );
+
+      let focused = foreignDocument.getElementById("focused");
+      (foreignDocument.activeElement === focused).should.equal(true);
+      focused.selectionStart.should.equal(1);
+      focused.selectionEnd.should.equal(2);
+    });
+
     it("restores focus and selection state with outerHTML morphStyle", function () {
       const div = make(`
         <div>


### PR DESCRIPTION
Hi!

While using idiomorph at Walnut, we hit a bug that we've been carrying as a local patch — contributing the fix upstream.

## The bug

Passing a node created in another JS realm (e.g. an iframe's `contentDocument`) as `newContent` throws:

```
TypeError: newContent is not iterable
    at normalizeParent (src/idiomorph.js)
    at Object.morph (src/idiomorph.js)
```

Repro:

```js
const target = document.querySelector("#target");
const iframe = document.createElement("iframe");
document.body.append(iframe);
const foreign = iframe.contentDocument.createElement("button");
foreign.textContent = "Bar";
Idiomorph.morph(target, foreign); // 💥 TypeError: newContent is not iterable
```

Every realm has its own constructors, so cross-realm nodes fail `instanceof Node` in `normalizeParent` and fall through to the array/HTMLCollection branch, which blows up on the spread.

The crash is only the visible part. `instanceof` stays false for these nodes **even after they are adopted into this document**, so once past normalization they also silently fail every other realm-sensitive `instanceof` check: template content handling, id-based matching of new children (`newChild instanceof Element`), and `syncInputValue` — meaning input/option/textarea values would silently not sync from cross-realm content. The second test demonstrates that.

We hit this in production at Walnut, where we morph DOM captured from customer apps across document boundaries — we've been carrying a fix as a local patch since 0.7.2.

## The fix

Replace realm-sensitive `instanceof` checks with tiny duck-typing helpers (`nodeType` / `localName`) — the same approach morphdom uses. The helpers carry JSDoc type predicates, so TypeScript narrows exactly like `instanceof` did and `npm run typecheck` stays green. The `document.activeElement` checks in the focus-preservation code keep `instanceof`, since the active element always belongs to this document.

First commit adds the failing tests, second commit makes them pass. There is a dedicated test per converted check — entry normalization, id-based element preservation (both the dummy-parent and `SlicedParentNode` paths), template content morphing, input/option/textarea value syncing, head handling, and Document normalization — and each test was verified to fail if its single check alone is reverted to `instanceof`. `npm run typecheck`, `npm run format:check`, and the full suite pass, with coverage at 100%.

Relates to #103 — whichever direction the `newContent` type-narrowing goes, cross-realm nodes currently crash rather than being handled or rejected cleanly, so this seems worth fixing today.
