### PR TITLE
collapse redundant type unions in newContent JSDoc

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -84,7 +84,7 @@
  * @callback Morph
  *
  * @param {Element | Document} oldNode
- * @param {Element | Node | HTMLCollection | Node[] | string | null} newContent
+ * @param {Node | HTMLCollection | Node[] | string | null} newContent
  * @param {Config} [config]
  * @returns {Promise<Node[]> | Node[]}
  */
@@ -149,7 +149,7 @@ var Idiomorph = (function () {
    * Core idiomorph function for morphing one DOM tree to another
    *
    * @param {Element | Document} oldNode
-   * @param {Element | Node | HTMLCollection | Node[] | string | null} newContent
+   * @param {Node | HTMLCollection | Node[] | string | null} newContent
    * @param {Config} [config]
    * @returns {Promise<Node[]> | Node[]}
    */
@@ -1228,7 +1228,7 @@ var Idiomorph = (function () {
 
     /**
      *
-     * @param {null | string | Node | HTMLCollection | Node[] | Document & {generatedByIdiomorph:boolean}} newContent
+     * @param {null | string | Node | HTMLCollection | Node[]} newContent
      * @returns {Element}
      */
     function normalizeParent(newContent) {


### PR DESCRIPTION
Small type-hygiene cleanup, no behaviour change. Prompted by #103, which asks whether the `newContent` possibility space can be pared down — part of it turns out to be double-counted already.

## `Element | Node` is just `Node`

`Element` extends `Node`, so the union in both public `newContent` annotations denotes exactly the same type with or without the `Element` arm:

```diff
- * @param {Element | Node | HTMLCollection | Node[] | string | null} newContent
+ * @param {Node | HTMLCollection | Node[] | string | null} newContent
```

#103 lists six accepted types; five of them are distinct. Worth knowing before deciding what to remove — and `HTMLCollection` / `Node[]` are both just node iterables, so the count of genuinely distinct *shapes* is lower still.

## A dead intersection in `normalizeParent`

```diff
-     * @param {null | string | Node | HTMLCollection | Node[] | Document & {generatedByIdiomorph:boolean}} newContent
+     * @param {null | string | Node | HTMLCollection | Node[]} newContent
```

`Document & {generatedByIdiomorph: boolean}` is redundant twice over. It is absorbed by `Node` like the arms above, and the property it names does not exist — `generatedByIdiomorph` is a `WeakSet` (src/idiomorph.js:1216), never a field on a document.

It looks vestigial rather than intentional. The WeakSet landed in 7f07002 (2024-11-23); the intersection was added later in e4eeb8a (2025-01-14), titled "satisfy tsc". The `/** @type {Element} */` cast on the `.has()` call covers that now, so removing it is clean.

## Verification

`npm run typecheck` silent, `npm run format:check` clean, chromium suite 182 passed / 0 failed, coverage 100 %, and `node test/lib/ensure-full-coverage.js` exits 0.

Since the annotations denote identical types, the generated `dist/*.d.ts` are unaffected in substance and no consumer can observe the change.

## Note

Marked draft — happy to close it if this is churn rather than cleanup, or to fold it into whatever comes out of #103. It merges cleanly against both #155 and #156 (checked), so it should not get in their way either.
