### PR TITLE
Read `ownerDocument` off the Node prototype

### DIFF
--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -1459,13 +1459,13 @@ var Idiomorph = (function () {
    * instead, which is also realm-safe: it brand-checks the internal slot
    * rather than the realm the node was created in.
    */
-  /** @type {(() => Document) | undefined} */
+  /** @type {((this: Node) => Document) | undefined} */
   let ownerDocumentGetter;
 
   /** @param {Node} node @returns {Document} */
   const ownerDocumentOf = (node) => {
     // Resolve lazily so importing the module does not require a DOM.
-    ownerDocumentGetter ??= /** @type {() => Document} */ (
+    ownerDocumentGetter ??= /** @type {(this: Node) => Document} */ (
       /** @type {PropertyDescriptor} */ (
         Object.getOwnPropertyDescriptor(Node.prototype, "ownerDocument")
       ).get

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -1459,14 +1459,19 @@ var Idiomorph = (function () {
    * instead, which is also realm-safe: it brand-checks the internal slot
    * rather than the realm the node was created in.
    */
-  const ownerDocumentGetter = /** @type {() => Document} */ (
-    /** @type {PropertyDescriptor} */ (
-      Object.getOwnPropertyDescriptor(Node.prototype, "ownerDocument")
-    ).get
-  );
+  /** @type {(() => Document) | undefined} */
+  let ownerDocumentGetter;
 
   /** @param {Node} node @returns {Document} */
-  const ownerDocumentOf = (node) => ownerDocumentGetter.call(node);
+  const ownerDocumentOf = (node) => {
+    // Resolve lazily so importing the module does not require a DOM.
+    ownerDocumentGetter ??= /** @type {() => Document} */ (
+      /** @type {PropertyDescriptor} */ (
+        Object.getOwnPropertyDescriptor(Node.prototype, "ownerDocument")
+      ).get
+    );
+    return ownerDocumentGetter.call(node);
+  };
 
   //=============================================================================
   // This is what ends up becoming the Idiomorph global object

--- a/src/idiomorph.js
+++ b/src/idiomorph.js
@@ -1019,7 +1019,7 @@ var Idiomorph = (function () {
         throw `Do not understand how to morph head style ${headStyle}`;
       }
 
-      const doc = oldNode.ownerDocument;
+      const doc = ownerDocumentOf(oldNode);
 
       return {
         target: oldNode,
@@ -1451,6 +1451,22 @@ var Idiomorph = (function () {
       textAreaElement: (value) => htmlElement(value, "textarea"),
     };
   })();
+
+  /**
+   * `<form>` is [LegacyOverrideBuiltIns], so a named control such as
+   * `<input name="ownerDocument">` installs an own property on the form that
+   * shadows `Node.prototype.ownerDocument`. Read through the prototype getter
+   * instead, which is also realm-safe: it brand-checks the internal slot
+   * rather than the realm the node was created in.
+   */
+  const ownerDocumentGetter = /** @type {() => Document} */ (
+    /** @type {PropertyDescriptor} */ (
+      Object.getOwnPropertyDescriptor(Node.prototype, "ownerDocument")
+    ).get
+  );
+
+  /** @param {Node} node @returns {Document} */
+  const ownerDocumentOf = (node) => ownerDocumentGetter.call(node);
 
   //=============================================================================
   // This is what ends up becoming the Idiomorph global object

--- a/test/core.js
+++ b/test/core.js
@@ -1,4 +1,14 @@
 describe("Core morphing tests", function () {
+  it("can load before DOM constructors are available", async function () {
+    const source = await (await fetch("/src/idiomorph.js")).text();
+    const load = new Function(
+      "Node",
+      "Element",
+      source + "; return Idiomorph;",
+    );
+    load(undefined, undefined).morph.should.be.a("function");
+  });
+
   setup();
   it("morphs outerHTML by default", function () {
     let initial = make("<button>Foo</button>");

--- a/test/restore-focus.js
+++ b/test/restore-focus.js
@@ -43,6 +43,35 @@ describe("Option to forcibly restore focus after morph", function () {
       focused.selectionEnd.should.equal(2);
     });
 
+    it("restores focus and selection state when the target form shadows ownerDocument", function () {
+      // a <form> is [LegacyOverrideBuiltIns]: a named control installs an own
+      // property that shadows Node.prototype.ownerDocument
+      let form = make(`<form></form>`);
+      getWorkArea().append(form);
+      form.innerHTML = `<input name="ownerDocument">
+        <div id="left"><input type="text" id="focused" value="abc"></div>
+        <div id="right"><input type="text" id="other"></div>`;
+      for (const elt of form.querySelectorAll("input")) {
+        elt.parentElement.moveBefore = undefined;
+      }
+      let input = document.getElementById("focused");
+      input.focus();
+      input.setSelectionRange(1, 2);
+
+      Idiomorph.morph(
+        form,
+        `<input name="ownerDocument">
+        <div id="left"><input type="text" id="other"></div>
+        <div id="right"><input type="text" id="focused" value="abc"></div>`,
+        { morphStyle: "innerHTML" },
+      );
+
+      let focused = document.getElementById("focused");
+      (document.activeElement === focused).should.equal(true);
+      focused.selectionStart.should.equal(1);
+      focused.selectionEnd.should.equal(2);
+    });
+
     it("restores focus and selection state with outerHTML morphStyle", function () {
       const div = make(`
         <div>


### PR DESCRIPTION
> [!NOTE]
> This and #164 are pre-emptive fixes to possible issues that I found when reviewing @lizarusi's #156 

A form control named `ownerDocument` shadows the form's DOM property, causing morphing to fail when creating the pantry in the target document.

Resolve `ctx.doc` through the native `Node` getter. Cache it on first use so importing the module does not require a DOM.

Tests cover focus and selection restoration on a shadowing form and loading without DOM constructors.
